### PR TITLE
Various updates

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1126,6 +1126,8 @@ SCAJ-20146:
   name: "Wang Da Yu Ju Xiang"
   region: "NTSC-Ch"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -1372,6 +1374,8 @@ SCAJ-20195:
 SCAJ-20196:
   name: "Wang Da Yu Ju Xiang [PlayStation 2 The Best]"
   region: "NTSC-Ch"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -2389,6 +2393,14 @@ SCED-53932:
 SCED-53939:
   name: "Official PlayStation 2 Magazine Demo 67" # Australian
   region: "PAL-E"
+SCED-53962:
+  name: "Shadow of the Colossus [Demo]"
+  region: "PAL-M5"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCED-53978:
   name: "Official PlayStation 2 Magazine Demo 69"
   region: "PAL-M5"
@@ -3660,6 +3672,8 @@ SCES-53326:
   name: "Shadow of the Colossus"
   region: "PAL-E"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -4827,6 +4841,8 @@ SCKA-20061:
   name: "Wanda to Kyozou"
   region: "NTSC-K"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -5663,6 +5679,8 @@ SCPS-15097:
   name: "Wanda to Kyozou"
   region: "NTSC-J"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -6098,6 +6116,8 @@ SCPS-19319:
 SCPS-19320:
   name: "Wanda to Kyozou [PlayStation 2 The Best]"
   region: "NTSC-J"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -6109,6 +6129,14 @@ SCPS-19320:
     - "SCPS-19103"
     - "SCPS-19151"
     - "SCPS-55001"
+SCPS-19335:
+  name: "Wanda to Kyozou [PlayStation 2 The Best Reprint]"
+  region: "NTSC-J"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
+  gsHWFixes:
+    mipmap: 1
+    halfPixelOffset: 1 # Fixes misalignments and borders on side.
 SCPS-19321:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -7846,6 +7874,8 @@ SCUS-97472:
   name: "Shadow of the Colossus"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -8024,6 +8054,8 @@ SCUS-97504:
 SCUS-97505:
   name: "Shadow of the Colossus [Demo]"
   region: "NTSC-U"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Alleviates excessive VU load.
   gsHWFixes:
     mipmap: 1
     halfPixelOffset: 1 # Fixes misalignments and borders on side.
@@ -8880,6 +8912,9 @@ SLED-53983:
   region: "PAL"
   gameFixes:
     - GIFFIFOHack # Fixes flag corruption.
+SLED-54032:
+  name: "Sonic Riders [Demo]"
+  region: "PAL-E"
 SLED-54035:
   name: "Play the Best Demos from Atari [Demo]"
   region: "PAL-M5"
@@ -12169,6 +12204,8 @@ SLES-51526:
 SLES-51541:
   name: "Grand Theft Auto - San Andreas"
   region: "PAL-Unk"
+  clampModes:
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLES-51547:
@@ -14032,6 +14069,8 @@ SLES-52482:
   name: "Steel Dragon EX"
   region: "PAL-M4"
   compat: 5
+  gsHWFixes:
+    gpuPaletteConversion: 2 # Fixes hashcache exploding.
 SLES-52483:
   name: "World Championship Pool 2004"
   region: "PAL-UM3"
@@ -14165,7 +14204,7 @@ SLES-52541:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLES-52542:
@@ -14276,6 +14315,13 @@ SLES-52573:
   region: "PAL-M5"
   roundModes:
     eeRoundMode: 2 # Fixes abnormal character behaviour.
+SLED-52574:
+  name: "Crash Twinsanity & Spyro - A Hero's Tail [Demo]"
+  region: "PAL-E"
+  gameFixes:
+    - XGKickHack # Fixes bad geometry.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLES-52576:
   name: "Yu-Gi-Oh! Capsule Monster Coliseum"
   region: "PAL-M5"
@@ -15076,7 +15122,7 @@ SLES-52927:
   name: "Grand Theft Auto - San Andreas"
   region: "PAL-G"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLES-52931:
@@ -22981,7 +23027,7 @@ SLPM-55092:
   name: "Grand Theft Auto - San Andreas [Best Price]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-55096:
@@ -23318,7 +23364,7 @@ SLPM-55292:
   name: "Grand Theft Auto - San Andreas [Rockstar Classics]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-55298:
@@ -24588,6 +24634,8 @@ SLPM-62395:
   name: "Simple 2000 Series Vol. 37 - The Shooting - Double Shienryu"
   region: "NTSC-J"
   compat: 5
+  gsHWFixes:
+    gpuPaletteConversion: 2 # Fixes hashcache from exploding.
 SLPM-62396:
   name: "Simple 2000 Honkaku Shikou Series Vol. 6 - The Card"
   region: "NTSC-J"
@@ -29005,7 +29053,7 @@ SLPM-65984:
   name: "Grand Theft Auto - San Andreas"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-65985:
@@ -31924,7 +31972,7 @@ SLPM-66788:
   name: "Grand Theft Auto - San Andreas [Best Price]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLPM-66789:
@@ -42173,6 +42221,8 @@ SLUS-20884:
   name: "Spyro - A Hero's Tail"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned bloom effects that streak on-screen, causes occasional trash shadows at places.
 SLUS-20885:
   name: "Red Star, The"
   region: "NTSC-U"
@@ -42490,7 +42540,7 @@ SLUS-20946:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
+    eeClampMode: 2 # Fixes Game freezes during "Reuniting The Families" mission.
   gsHWFixes:
     autoFlush: 1
 SLUS-20947:
@@ -47740,6 +47790,8 @@ SLUS-29101:
   region: "NTSC-U"
   gameFixes:
     - XGKickHack # Fixes bad geometry.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
 SLUS-29104:
   name: "Galactic Wrestling - Featuring Ultimate Muscle [Demo]"
   region: "NTSC-U"

--- a/xbsx2/Config.h
+++ b/xbsx2/Config.h
@@ -512,7 +512,7 @@ struct Xbsx2Config
 		bool SynchronousMTGS{false};
 		bool FrameLimitEnable{true};
 
-		VsyncMode VsyncEnable{VsyncMode::Off};
+		VsyncMode VsyncEnable{VsyncMode::On};
 
 		float LimitScalar{1.0f};
 		float FramerateNTSC{DEFAULT_FRAME_RATE_NTSC};
@@ -533,7 +533,7 @@ struct Xbsx2Config
 
 		float OsdScale{100.0f};
 
-		GSRendererType Renderer{GSRendererType::Auto};
+		GSRendererType Renderer{GSRendererType::DX12};
 		uint UpscaleMultiplier{1};
 
 		HWMipmapLevel HWMipmap{HWMipmapLevel::Automatic};

--- a/xbsx2/Frontend/FullscreenUI.cpp
+++ b/xbsx2/Frontend/FullscreenUI.cpp
@@ -3445,7 +3445,7 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 	DrawToggleSetting(bsi, "Dump FMV Textures", "Allows texture dumping when FMVs are active. You should not enable this.", "EmuCore/GS", "DumpTexturesWithFMVActive", false, dumping_active);
 	DrawToggleSetting(bsi, "Load Textures", "Loads replacement textures where available and user-provided.", "EmuCore/GS", "LoadTextureReplacements", false);
 	DrawToggleSetting(bsi, "Asynchronous Texture Loading", "Loads replacement textures on a worker thread, reducing microstutter when replacements are enabled.", "EmuCore/GS", "LoadTextureReplacementsAsync", true, replacement_active);
-	DrawToggleSetting(bsi, "Precache Replacements", "Preloads all replacement textures to memory. Not necessary with asynchronous loading.", "EmuCore/GS", "PrecacheTextureReplacements", false, replacement_active);
+	//  DrawToggleSetting(bsi, "Precache Replacements", "Preloads all replacement textures to memory. Not necessary with asynchronous loading.", "EmuCore/GS", "PrecacheTextureReplacements", false, replacement_active);
 
 	MenuHeading("Logging");
 
@@ -3455,9 +3455,9 @@ void FullscreenUI::DrawAdvancedSettingsPage()
 	DrawToggleSetting(bsi, "IOP Console", "Writes debug messages from the game's IOP code to the console.", "Logging", "EnableIOPConsole", true);
 	DrawToggleSetting(bsi, "CDVD Verbose Reads", "Logs disc reads from games.", "EmuCore", "CdvdVerboseReads", false);
 
-	MenuHeading("Graphics");
+	/* MenuHeading("Graphics");
 
-	DrawToggleSetting(bsi, "Use Debug Device", "Enables API-level validation of graphics commands", "EmuCore/GS", "UseDebugDevice", false);
+	DrawToggleSetting(bsi, "Use Debug Device", "Enables API-level validation of graphics commands", "EmuCore/GS", "UseDebugDevice", false); */
 
 	EndMenuButtons();
 }

--- a/xbsx2/GS/Renderers/Common/GSDevice.h
+++ b/xbsx2/GS/Renderers/Common/GSDevice.h
@@ -648,8 +648,8 @@ struct alignas(16) GSHWDrawConfig
 	GSTexture* ds;        ///< Depth stencil
 	GSTexture* tex;       ///< Source texture
 	GSTexture* pal;       ///< Palette texture
-	GSVertex* verts;      ///< Vertices to draw
-	u32* indices;         ///< Indices to draw
+	const GSVertex* verts;      ///< Vertices to draw
+	const u32* indices;         ///< Indices to draw
 	u32 nverts;           ///< Number of vertices
 	u32 nindices;         ///< Number of indices
 	u32 indices_per_prim; ///< Number of indices that make up one primitive

--- a/xbsx2/GS/Renderers/DX12/GSDevice12.cpp
+++ b/xbsx2/GS/Renderers/DX12/GSDevice12.cpp
@@ -2180,7 +2180,7 @@ bool GSDevice12::ApplyTFXState(bool already_execed)
 		return true;
 
 	u32 flags = m_dirty_flags;
-	m_dirty_flags &= ~DIRTY_TFX_STATE | DIRTY_CONSTANT_BUFFER_STATE;
+	m_dirty_flags &= ~(DIRTY_TFX_STATE | DIRTY_CONSTANT_BUFFER_STATE);
 
 	// do cbuffer first, because it's the most likely to cause an exec
 	if (flags & DIRTY_FLAG_VS_CONSTANT_BUFFER)

--- a/xbsx2/GS/Renderers/HW/GSTextureCache.cpp
+++ b/xbsx2/GS/Renderers/HW/GSTextureCache.cpp
@@ -1177,9 +1177,14 @@ void GSTextureCache::InvalidateLocalMem(const GSOffset& off, const GSVector4i& r
 
 bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u32 DBW, u32 DPSM, int dx, int dy, int w, int h)
 {
+	if (SBP == DBP && SPSM == DPSM && !GSLocalMemory::m_psm[SPSM].depth && ShuffleMove(SBP, SBW, SPSM, sx, sy, dx, dy, w, h))
+	{
+		return true;
+	}
+
 	// TODO: In theory we could do channel swapping on the GPU, but we haven't found anything which needs it so far.
 	// Same with SBP == DBP, but this behavior could change based on direction?
-	if (SPSM != DPSM || SBP == DBP)
+	if (SPSM != DPSM || ((SBP == DBP) && !(GSVector4i(sx, sy, sx + w, sy + h).rintersect(GSVector4i(dx, dy, dx + w, dy + h))).rempty()))
 	{
 		GL_CACHE("Skipping HW move from 0x%X to 0x%X with SPSM=%u DPSM=%u", SBP, DBP, SPSM, DPSM);
 		return false;
@@ -1240,6 +1245,131 @@ bool GSTextureCache::Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u
 
 	// Invalidate any sources that overlap with the target (since they're now stale).
 	InvalidateVideoMem(g_gs_renderer->m_mem.GetOffset(DBP, DBW, DPSM), GSVector4i(dx, dy, dx + w, dy + h), false);
+	return true;
+}
+
+bool GSTextureCache::ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx, int dy, int w, int h)
+{
+	// What are we doing here? Final Fantasy XII uses moves to copy the contents of the RG channels to the BA channels,
+	// by rendering in PSMCT32, and doing a PSMCT16 move with an 8x0 offset on the destination. This effectively reads
+	// from the original red/green channels, and writes to the blue/alpha channels. Who knows why they did it this way,
+	// when they could've used sprites, but it means that they had to offset the block pointer for each move. So, we
+	// need to use tex-in-rt here to figure out what the offset into the original PSMCT32 texture was, and HLE the move.
+	if (PSM != PSM_PSMCT16)
+		return false;
+
+	GL_CACHE("Trying ShuffleMove: BP=%04X BW=%u PSM=%u SX=%d SY=%d DX=%d DY=%d W=%d H=%d", BP, BW, PSM, sx, sy, dx, dy, w, h);
+
+	GSTextureCache::Target* tgt = nullptr;
+	for (auto t : m_dst[RenderTarget])
+	{
+		if (t->m_TEX0.PSM == PSM_PSMCT32 && BP >= t->m_TEX0.TBP0 && BP <= t->m_end_block)
+		{
+			SurfaceOffset so(ComputeSurfaceOffset(BP, BW, PSM, GSVector4i(sx, sy, sx + w, sy + h), t));
+			if (so.is_valid)
+			{
+				tgt = t;
+				GL_CACHE("ShuffleMove: Surface offset %d,%d from BP %04X - %04X", so.b2a_offset.x, so.b2a_offset.y, BP, t->m_TEX0.TBP0);
+				sx += so.b2a_offset.x;
+				sy += so.b2a_offset.y;
+				dx += so.b2a_offset.x;
+				dy += so.b2a_offset.y;
+				break;
+			}
+		}
+	}
+	if (!tgt)
+	{
+		GL_CACHE("ShuffleMove: No target found");
+		return false;
+	}
+
+	// Since we're only concerned with 32->16 shuffles, the difference should be 8x8 for this to work.
+	const s32 diff_x = (dx - sx);
+	if (std::abs(diff_x) != 8 || sy != dy)
+	{
+		GL_CACHE("ShuffleMove: Difference is not 8 pixels");
+		return false;
+	}
+
+	const bool read_ba = (diff_x < 0);
+	const bool write_rg = (diff_x < 0);
+
+	const GSVector4i bbox(write_rg ? GSVector4i(dx, dy, dx + w, dy + h) : GSVector4i(sx, sy, sx + w, sy + h));
+
+	GSVertex vertices[4] = {};
+#define V(i, x, y, u, v) \
+	do \
+	{ \
+		vertices[i].XYZ.X = x; \
+		vertices[i].XYZ.Y = y; \
+		vertices[i].U = u; \
+		vertices[i].V = v; \
+	} while (0)
+
+	const GSVector4i bbox_fp(bbox.sll32(4));
+	V(0, bbox_fp.x, bbox_fp.y, bbox_fp.x, bbox_fp.y); // top-left
+	V(1, bbox_fp.z, bbox_fp.y, bbox_fp.z, bbox_fp.y); // top-right
+	V(2, bbox_fp.x, bbox_fp.w, bbox_fp.x, bbox_fp.w); // bottom-left
+	V(3, bbox_fp.z, bbox_fp.w, bbox_fp.z, bbox_fp.w); // bottom-right
+
+#undef V
+
+	static constexpr u32 indices[6] = {0, 1, 2, 2, 1, 3};
+
+	// If we ever do this sort of thing somewhere else, extract this to a helper function.
+	GSHWDrawConfig config;
+	config.rt = tgt->m_texture;
+	config.ds = nullptr;
+	config.tex = tgt->m_texture;
+	config.pal = nullptr;
+	config.indices = indices;
+	config.verts = vertices;
+	config.nverts = static_cast<u32>(std::size(vertices));
+	config.nindices = static_cast<u32>(std::size(indices));
+	config.indices_per_prim = 3;
+	config.drawlist = nullptr;
+	config.scissor = GSVector4i(0, 0, tgt->m_texture->GetWidth(), tgt->m_texture->GetHeight());
+	config.drawarea = GSVector4i(GSVector4(bbox) * GSVector4(tgt->m_texture->GetScale()).xxyy());
+	config.topology = GSHWDrawConfig::Topology::Triangle;
+	config.blend = GSHWDrawConfig::BlendState();
+	config.depth = GSHWDrawConfig::DepthStencilSelector::NoDepth();
+	config.colormask = GSHWDrawConfig::ColorMaskSelector();
+	config.colormask.wrgba = (write_rg ? (1 | 2) : (4 | 8));
+	config.require_one_barrier = true;
+	config.require_full_barrier = false;
+	config.destination_alpha = GSHWDrawConfig::DestinationAlphaMode::Off;
+	config.datm = false;
+	config.line_expand = false;
+	config.separate_alpha_pass = false;
+	config.second_separate_alpha_pass = false;
+	config.alpha_second_pass.enable = false;
+	config.vs.key = 0;
+	config.vs.tme = true;
+	config.vs.iip = true;
+	config.vs.fst = true;
+	config.gs.key = 0;
+	config.ps.key_lo = 0;
+	config.ps.key_hi = 0;
+	config.ps.read_ba = read_ba;
+	config.ps.write_rg = write_rg;
+	config.ps.shuffle = true;
+	config.ps.iip = true;
+	config.ps.fst = true;
+	config.ps.tex_is_fb = true;
+	config.ps.tfx = TFX_DECAL;
+
+	const GSVector2i rtsize(tgt->m_texture->GetSize());
+	const GSVector2 rtscale(tgt->m_texture->GetScale());
+	config.cb_ps.WH = GSVector4(static_cast<float>(rtsize.x) / rtscale.x, static_cast<float>(rtsize.y) / rtscale.y,
+		static_cast<float>(rtsize.x), static_cast<float>(rtsize.y));
+	config.cb_ps.STScale = rtscale;
+
+	config.cb_vs.vertex_scale = GSVector2(2.0f * rtscale.x / (rtsize.x << 4), 2.0f * rtscale.y / (rtsize.y << 4));
+	config.cb_vs.vertex_offset = GSVector2(-1.0f / rtsize.x + 1.0f, -1.0f / rtsize.y + 1.0f);
+	config.cb_vs.texture_scale = GSVector2((1.0f / 16.0f) / config.cb_ps.WH.x, (1.0f / 16.0f) / config.cb_ps.WH.y);
+
+	g_gs_device->RenderHW(config);
 	return true;
 }
 

--- a/xbsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/xbsx2/GS/Renderers/HW/GSTextureCache.h
@@ -349,6 +349,7 @@ public:
 	void InvalidateVideoMem(const GSOffset& off, const GSVector4i& r, bool target = true);
 	void InvalidateLocalMem(const GSOffset& off, const GSVector4i& r);
 	bool Move(u32 SBP, u32 SBW, u32 SPSM, int sx, int sy, u32 DBP, u32 DBW, u32 DPSM, int dx, int dy, int w, int h);
+	bool ShuffleMove(u32 BP, u32 BW, u32 PSM, int sx, int sy, int dx, int dy, int w, int h);
 
 	void IncAge();
 

--- a/xbsx2/PAD/Host/PAD.cpp
+++ b/xbsx2/PAD/Host/PAD.cpp
@@ -476,9 +476,9 @@ static const PAD::ControllerSettingInfo s_dualshock2_settings[] = {
 	{PAD::ControllerSettingInfo::Type::Float, "ButtonDeadzone", "Button/Trigger Deadzone",
 		"Sets the deadzone for activating buttons/triggers, i.e. the fraction of the trigger which will be ignored.",
 		"0.00", "0", "100", "1", "%.0f%%", nullptr, 100.0f},
-	/* {PAD::ControllerSettingInfo::Type::Float, "PressureModifier", "Modifier Pressure",
+	{PAD::ControllerSettingInfo::Type::Float, "PressureModifier", "Modifier Pressure",
 		"Sets the pressure when the modifier button is held.",
-		"25", "0", "25", "1", "%.0f%%", nullptr, 100.0f}, */
+		"0.25", "0", "25", "1", "%.0f%%", nullptr, 100.0f},
 };
 
 static const PAD::ControllerInfo s_controller_info[] = {

--- a/xbsx2/VMManager.cpp
+++ b/xbsx2/VMManager.cpp
@@ -695,7 +695,12 @@ void VMManager::UpdateRunningGame(bool resetting, bool game_starting)
 	UpdateGameSettingsLayer();
 	ApplySettings();
 
-	// check this here, for two cases: dynarec on, and when enable cheats is set per-game.
+	// Clear the memory card eject notification again when booting for the first time, or starting.
+	// Otherwise, games think the card was removed on boot.
+	if (game_starting || resetting)
+		ClearMcdEjectTimeoutNow();
+
+	// Check this here, for two cases: dynarec on, and when enable cheats is set per-game.
 	if (s_patches_crc != s_game_crc)
 		ReloadPatches(game_starting, false);
 


### PR DESCRIPTION
- Enables D3D12 and VSync by default on fresh configs.

- Reactivates the button Pressure Modifier.

- GameDB Updates.

- Removes "Precache Texture Replacements" and "Use Debug Device".

Backport - VMManager: Fix per-game memory cards getting ejected on boot https://github.com/PCSX2/pcsx2/commit/d5e8fadc649ceafb76bb4014e1baaecc089c4817

Backport - GS/HW: Vertex/index pointers should be constant https://github.com/PCSX2/pcsx2/commit/5d7ab543407569121a36797668c3a229ef7a324b

Backport - GS/HW: HLE shuffles (more like copies) done through moves https://github.com/PCSX2/pcsx2/commit/000de4c72e0f4bfcdcf221d2bac16cbfe1fd1887