### PR TITLE
Backports and Updates

### DIFF
--- a/bin/resources/GameIndex.yaml
+++ b/bin/resources/GameIndex.yaml
@@ -1095,6 +1095,8 @@ SCAJ-20138:
   region: "NTSC-Unk"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCAJ-20139:
   name: "Zero - Shisei no Koe" # Fatal Frame - Rei - Irezumi no Sei
   region: "NTSC-Unk"
@@ -1371,6 +1373,8 @@ SCAJ-20195:
   region: "NTSC-Ch"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCAJ-20196:
   name: "Wang Da Yu Ju Xiang [PlayStation 2 The Best]"
   region: "NTSC-Ch"
@@ -1531,7 +1535,8 @@ SCCS-40001:
   name: "Ape Escape 2"
   region: "NTSC-C"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCCS-40002:
   name: "Devil May Cry 2 - Disc 1"
   region: "NTSC-C"
@@ -2171,6 +2176,13 @@ SCED-52687:
 SCED-52728:
   name: "Official PlayStation 2 Magazine Demo 49"
   region: "PAL-M5"
+SCED-52759:
+  name: "Killzone [Demo]"
+  region: "PAL-M5"
+  clampModes:
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SCED-52785:
   name: "Official PlayStation 2 Magazine Demo 50"
   region: "PAL-M5"
@@ -2183,9 +2195,13 @@ SCED-52796:
 SCED-52818:
   name: "EyeToy - Chat [Light]"
   region: "PAL-M11"
-SCED-52889:
-  name: "Killzone [Bonus Disc]"
-  region: "PAL-M5"
+SCED-52846:
+  name: "Killzone [Demo]"
+  region: "PAL-E"
+  clampModes:
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SCED-52932:
   name: "Bonus Demo 8"
   region: "PAL-M5"
@@ -2567,6 +2583,9 @@ SCED-54605:
 SCED-54642:
   name: "Official PlayStation 2 Magazine Demo 82" # German
   region: "PAL-M5"
+SCED-54682:
+  name: "UPS2 Speciale Platinum 2007"
+  region: "PAL-M5"
 SCED-54692:
   name: "Official PlayStation 2 Magazine Demo 83" # German
   region: "PAL-E-G"
@@ -2908,7 +2927,8 @@ SCES-50885:
   name: "Ape Escape 2"
   region: "PAL-E"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-50887:
   name: "Alpine Racer 3"
   region: "PAL-M5"
@@ -2933,7 +2953,7 @@ SCES-50916:
   gsHWFixes:
     mipmap: 1
 SCES-50917:
-  name: "Sly Racoon"
+  name: "Sly Raccoon"
   region: "PAL-M5"
 SCES-50928:
   name: "SOCOM - U.S. Navy SEALs [Beta & Full Release]"
@@ -3010,22 +3030,26 @@ SCES-51102:
   name: "Ape Escape 2"
   region: "PAL-F"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51103:
   name: "Ape Escape 2"
   region: "PAL-I"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51104:
   name: "Ape Escape 2"
   region: "PAL-G"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51105:
   name: "Ape Escape 2"
   region: "PAL-S"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-51135:
   name: "Primal"
   region: "PAL-M5"
@@ -3447,9 +3471,11 @@ SCES-52460:
     autoFlush: 1
     preloadFrameData: 1 # Fixes Sony splash at boot.
 SCES-52529:
-  name: "Sly Racoon 2 - Band of Thieves"
+  name: "Sly 2 - Band of Thieves"
   region: "PAL-M11"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCES-52530:
   name: "Crisis Zone"
   region: "PAL-M5"
@@ -3608,6 +3634,13 @@ SCES-53247:
   compat: 5
   gameFixes:
     - XGKickHack # Fixes SPS.
+  patches:
+    CBBC2E7F:
+      content: |-
+        // https://forums.pcsx2.net/Thread-WRC-Rally-Evolved-run-problem?pid=617145#pid617145
+        // Fix "Branch 19e00047 in delay slot" which causes extreme slowdowns
+        // when you crash your car or interact with physics objects
+        patch=1,EE,003CC894,word,00000000
 SCES-53285:
   name: "Ratchet - Gladiator"
   region: "PAL-M5"
@@ -3705,7 +3738,7 @@ SCES-53397:
   name: "SingStar Pop - World Events Code"
   region: "PAL-Unk"
 SCES-53409:
-  name: "Sly 3"
+  name: "Sly 3 - Honour Among Thieves"
   region: "PAL-M11"
   compat: 5
   roundModes:
@@ -3756,6 +3789,8 @@ SCES-53642:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCES-53663:
   name: "Buzz! The Music Quiz"
   region: "PAL-M3"
@@ -4747,9 +4782,11 @@ SCKA-20043:
   name: "Magna Carta"
   region: "NTSC-K"
 SCKA-20044:
-  name: "Sly Cooper 2 Band of Thieves"
+  name: "Sly 2 - Band of Thieves"
   region: "NTSC-K"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCKA-20047:
   name: "Armored Core Nine Breaker"
   region: "NTSC-K"
@@ -4857,10 +4894,18 @@ SCKA-20062:
   region: "NTSC-K"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCKA-20063:
-  name: "Sly Cooper 3 Honor Among Thieves"
+  name: "Sly 3 - Honor Among Thieves"
   region: "NTSC-K"
   compat: 5
+  roundModes:
+    vuRoundMode: 0 # Fixes game engine issue with bombs and ladders.
+  clampModes:
+    vuClampMode: 2 # Fixes bugged camera.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCKA-20064:
   name: "SOCOM 3 - U.S. Navy SEALs"
   region: "NTSC-K"
@@ -5625,8 +5670,11 @@ SCPS-15089:
   name: "EyeToy - Play 2 [With Camera]"
   region: "NTSC-J"
 SCPS-15090:
-  name: "Sly Racoon 2"
+  name: "Kaitou Sly Cooper 2"
   region: "NTSC-J"
+  compat: 5
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes chromatic effect.
 SCPS-15091:
   name: "Wild ARMs - The 4th Detonator"
   region: "NTSC-J"
@@ -5931,7 +5979,8 @@ SCPS-19206:
   name: "Ape Escape 2 [PlayStation 2 The Best]"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19207:
   name: "Popolocrois Story - Hajime no Bouken [PlayStation 2 The Best]"
   region: "NTSC-J"
@@ -6200,6 +6249,8 @@ SCPS-19327:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-19328:
   name: "Ratchet & Clank 4th - GiriGiri Ginga no Giga Battle [PlayStation 2 the Best - Reprint]"
   region: "NTSC-J"
@@ -6432,7 +6483,8 @@ SCPS-55035:
   name: "Ape Escape 2"
   region: "NTSC-J"
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCPS-55038:
   name: "Pac-Man World 2"
   region: "NTSC-J"
@@ -8039,6 +8091,8 @@ SCUS-97501:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCUS-97502:
   name: "Tourist Trophy"
   region: "NTSC-U"
@@ -8212,6 +8266,8 @@ SCUS-97548:
   region: "NTSC-U"
   gsHWFixes:
     preloadFrameData: 1 # Fixes black background in the pause menu.
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SCUS-97554:
   name: "NBA '07 featuring The Life Vol.2 [Demo]"
   region: "NTSC-U"
@@ -8528,11 +8584,12 @@ SLAJ-25053:
   name: "Burnout 3 - Takedown"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLAJ-25055:
   name: "Def Jam - Fight for N.Y."
   region: "NTSC-Unk"
@@ -8561,11 +8618,12 @@ SLAJ-25066:
   name: "Burnout Revenge - Battle Racing Ignited"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -8667,10 +8725,12 @@ SLAJ-25094:
   name: "Burnout Dominator"
   region: "NTSC-Unk"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLAJ-25095:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-Unk"
@@ -8812,9 +8872,13 @@ SLED-52488:
 SLED-52597:
   name: "Burnout 3 - Takedown [Demo]"
   region: "PAL-E"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLED-52875:
   name: "Sega Superstars [Demo]"
   region: "PAL-E"
@@ -8825,6 +8889,13 @@ SLED-52890:
     - GIFFIFOHack # Partially fixes graphical issues also needs EE cycle rate + 3.
   gsHWFixes:
     mipmap: 1
+SLED-52899:
+  name: "Killzone [Bonus Disc]"
+  region: "PAL-M5"
+  clampModes:
+    vuClampMode: 0 # Resolves I Reg Clamping / performance impact and yellow graphics in certain areas.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes blurriness.
 SLED-52929:
   name: "Prince of Persia - Warrior Within [Demo]"
   region: "PAL-M5"
@@ -8851,11 +8922,12 @@ SLED-53512:
   region: "PAL-E"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLED-53537:
   name: "187 - Ride or Die [Demo]"
   region: "PAL-E"
@@ -14338,20 +14410,22 @@ SLES-52584:
   region: "PAL-M4"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLES-52585:
   name: "Burnout 3 - Takedown"
   region: "PAL-F-G-I"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLES-52587:
   name: "Army Men - Sarge's War"
   region: "PAL-M5"
@@ -16432,11 +16506,12 @@ SLES-53506:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -16448,11 +16523,12 @@ SLES-53507:
   region: "PAL-M3"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   memcardFilters:
     - "SLES-53506"
     - "SLES-53507"
@@ -16862,6 +16938,8 @@ SLES-53635:
 SLES-53636:
   name: "TY the Tasmanian Tiger 3 - Night of the Quinkan"
   region: "PAL-A"
+  roundModes:
+    eeRoundMode: 0 # Fixes story mission to make it completable.
 SLES-53638:
   name: "Ski Racing 2006"
   region: "PAL-M5"
@@ -19186,10 +19264,12 @@ SLES-54627:
   region: "PAL-M5"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLES-54628:
   name: "Skate Attack [Promo]"
   region: "PAL-E"
@@ -19298,6 +19378,8 @@ SLES-54663:
   name: "Jackass - The Game"
   region: "PAL-M5"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLES-54664:
   name: "Top Gun"
   region: "PAL-M11"
@@ -19345,10 +19427,12 @@ SLES-54681:
   name: "Burnout Dominator"
   region: "PAL-E"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLES-54683:
   name: "Medal of Honor - Vanguard"
   region: "PAL-M9"
@@ -20384,6 +20468,8 @@ SLES-55080:
 SLES-55081:
   name: "Jackass - The Game"
   region: "PAL-E"
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLES-55082:
   name: "Urban Constructor"
   region: "PAL-E"
@@ -20953,6 +21039,10 @@ SLES-55354:
 SLES-55355:
   name: "Guitar Hero - World Tour"
   region: "PAL-M5"
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Corrects note board position.
+  roundModes:
+    vuRoundMode: 0 # Fixes graphical issues ingame.
 SLES-55356:
   name: "Bratz - Girlz Really Rock"
   region: "PAL-M3"
@@ -20993,6 +21083,8 @@ SLES-55372:
   name: "Spiderman - Web of Shadows"
   region: "PAL-M5"
   compat: 5
+  clampModes:
+    eeClampMode: 3 # Connect hits, able to summon... etc...
 SLES-55373:
   name: "King of Fighters Collection, The - The Orochi Saga"
   region: "PAL-E"
@@ -21825,6 +21917,9 @@ SLKA-15011:
 SLKA-15013:
   name: "Grand Slam 2003 Tennis" # Hard Hitter 2
   region: "NTSC-K"
+SLKA-15015:
+  name: "Ichigeki Sacchuu!! HoiHoi-San"
+  region: "NTSC-K"
 SLKA-15016:
   name: "Harry Potter - Quidditch World Cup"
   region: "NTSC-K"
@@ -21844,6 +21939,9 @@ SLKA-15021:
 SLKA-15023:
   name: "Assault Suits Valken"
   region: "NTSC-K"
+SLKA-15025:
+  name: "Space Invaders Anniversary"
+  region: "NTSC-K"
 SLKA-15028:
   name: "Simple 2000 Series Ultimate Vol. 6 - Love - Upper!"
   region: "NTSC-K"
@@ -21852,6 +21950,9 @@ SLKA-15029:
   region: "NTSC-K"
 SLKA-15030:
   name: "Simple 2000 Series Vol. 5 - The Block Kuzushi Hyper"
+  region: "NTSC-K"
+SLKA-15031:
+  name: "Princess Maker"
   region: "NTSC-K"
 SLKA-15032:
   name: "Gradius V"
@@ -21952,6 +22053,11 @@ SLKA-25038:
     alignSprite: 1 # Fixes vertical lines.
     roundSprite: 2 # Fixes font artifacts.
     mergeSprite: 1 # Fixes flame-like bleeding.
+SLKA-25039:
+  name: "Burnout 2 - Point of Impact"
+  region: "NTSC-K"
+  roundModes:
+    vuRoundMode: 1 # Bright lights in cars.
 SLKA-25041:
   name: "Armored Core 3 Silent Line"
   region: "NTSC-K"
@@ -22104,6 +22210,9 @@ SLKA-25087:
   compat: 5
   clampModes:
     vuClampMode: 2 # Missing geometry with microVU.
+SLKA-25088:
+  name: "Sangokushi Senki 2"
+  region: "NTSC-K"
 SLKA-25090:
   name: "Starsky & Hutch"
   region: "NTSC-K"
@@ -22386,10 +22495,13 @@ SLKA-25205:
 SLKA-25206:
   name: "Burnout 3 - Takedown"
   region: "NTSC-K"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLKA-25207:
   name: "Sakura Taisen V - Episode 0 - Samurai Girl of Wild"
   region: "NTSC-K"
@@ -22413,6 +22525,7 @@ SLKA-25213:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
+    halfPixelOffset: 1 # Fixes misaligned blur around objects and enemies.
 SLKA-25214:
   name: "Final Fantasy X - International [PlayStation 2 - Big Hit Series]"
   region: "NTSC-K"
@@ -22452,6 +22565,9 @@ SLKA-25222:
   gsHWFixes:
     autoFlush: 1 # Fixes bloom.
     roundSprite: 1 # Fixes misalliged bloom.
+SLKA-25223:
+  name: "K.League - Winning Eleven 8 - Asia Championship"
+  region: "NTSC-K"
 SLKA-25224:
   name: "Detective Saburo Jinguji 9 - Kind of Blue"
   region: "NTSC-K"
@@ -22644,11 +22760,12 @@ SLKA-25304:
   name: "Burnout Revenge"
   region: "NTSC-K"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLKA-25307:
   name: "Dragon Ball Z Sparking"
   region: "NTSC-K"
@@ -22913,6 +23030,16 @@ SLPM-20436:
   name: "Sakigake!! Otokojuku"
   region: "NTSC-J"
   compat: 5
+SLPM-55004:
+  name: "Burnout Revenge (EASY 1980)"
+  region: "NTSC-J"
+  clampModes:
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
+    autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-55005:
   name: "Mana Khemia 2 - Ochita Gakuen to Renkinjutsushi Tachi"
   region: "NTSC-J"
@@ -22940,6 +23067,16 @@ SLPM-55024:
 SLPM-55033:
   name: "J. League Winning Eleven 2008 - Club Championship"
   region: "NTSC-J"
+SLPM-55036:
+  name: "Burnout Dominator (EASY 1980)"
+  region: "NTSC-J"
+  clampModes:
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
+  gsHWFixes:
+    halfPixelOffset: 2 # Fixes depth lines.
+    autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-55039:
   name: "Soukoku no Kusabi - Hiiro no Kakera 3 [Limited Edition]"
   region: "NTSC-J"
@@ -23467,11 +23604,12 @@ SLPM-60246:
   name: "Burnout 3 - Takedown [Trial]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-60251:
   name: "Devil May Cry 3 [Trial Version]"
   region: "NTSC-J"
@@ -25816,6 +25954,9 @@ SLPM-64540:
   region: "NTSC-K"
   speedHacks:
     MTVUSpeedHack: 0 # Fixes bad graphics due to bad T-Bit handling.
+SLPM-64544:
+  name: "Tetsu 1 - Densha de Battle! World Grand Prix"
+  region: "NTSC-K"
 SLPM-64549:
   name: "Siksin-ui Seong"
   region: "NTSC-K"
@@ -28037,6 +28178,7 @@ SLPM-65686:
   region: "NTSC-J"
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
+    halfPixelOffset: 1 # Fixes misaligned blur around objects and enemies.
 SLPM-65687:
   name: "Star Wars - Battlefront"
   region: "NTSC-J"
@@ -28046,6 +28188,7 @@ SLPM-65688:
   compat: 5
   gsHWFixes:
     preloadFrameData: 1 # Partially fixes HUD elements.
+    halfPixelOffset: 1 # Fixes misaligned blur around objects and enemies.
 SLPM-65689:
   name: "Never 7 - The End of Infinity [SuperLite 2000 Series]"
   region: "NTSC-J"
@@ -28147,11 +28290,12 @@ SLPM-65719:
   name: "Burnout 3 - Takedown"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65720:
   name: "Shin Sangoku Musou 2 Mushoden [Koei the Best]"
   region: "NTSC-J"
@@ -28965,11 +29109,12 @@ SLPM-65958:
   name: "Burnout 3 - Takedown [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-65959:
   name: "Standard Daisenryaku - Ushinawareta Shouri"
   region: "NTSC-J"
@@ -29479,11 +29624,12 @@ SLPM-66108:
   name: "Burnout Revenge"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -31433,11 +31579,12 @@ SLPM-66652:
   name: "Burnout Revenge [EA Best Hits]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   memcardFilters:
     - "SLAJ-25066"
     - "SLPM-66108"
@@ -31794,10 +31941,12 @@ SLPM-66739:
   name: "Burnout Dominator"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-66740:
   name: "Sentou Kokka Kai - Legend [DX Pack]"
   region: "NTSC-J"
@@ -32505,11 +32654,12 @@ SLPM-66962:
   name: "Burnout 3 - Takedown [EA-SY! 1980]"
   region: "NTSC-J"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLPM-66963:
   name: "Medal of Honor - Frontline [EA-SY! 1980]"
   region: "NTSC-J"
@@ -38566,7 +38716,7 @@ SLUS-20043:
   region: "NTSC-U"
   compat: 5
 SLUS-20044:
-  name: "Star Wars - StarFighter"
+  name: "Star Wars - Starfighter"
   region: "NTSC-U"
   compat: 5
 SLUS-20045:
@@ -41312,7 +41462,8 @@ SLUS-20685:
   region: "NTSC-U"
   compat: 5
   gsHWFixes:
-    mipmap: 1
+    mipmap: 2 # Fixes miptrick texture effects.
+    trilinearFiltering: 1 # Fixes miptrick blending.
 SLUS-20686:
   name: "Splashdown - Rides Gone Wild"
   region: "NTSC-U"
@@ -43098,11 +43249,12 @@ SLUS-21050:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-21051:
   name: "FIFA 2005"
   region: "NTSC-U"
@@ -44035,11 +44187,12 @@ SLUS-21242:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
   memcardFilters: # Reads Burnout 3 and NFL 06 saves for unlockables.
     - "SLUS-21242"
     - "SLUS-21050"
@@ -44106,6 +44259,8 @@ SLUS-21253:
   name: "Ty the Tasmanian Tiger 3"
   region: "NTSC-U"
   compat: 5
+  roundModes:
+    eeRoundMode: 0 # Fixes story mission to make it completable.
 SLUS-21254:
   name: "Zatch Bell! Mamodo Battles"
   region: "NTSC-U"
@@ -45752,10 +45907,12 @@ SLUS-21596:
   region: "NTSC-U"
   compat: 5
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
+    mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-21597:
   name: "Medal of Honor - Vanguard"
   region: "NTSC-U"
@@ -45932,6 +46089,8 @@ SLUS-21627:
   name: "Jackass - The Game"
   region: "NTSC-U"
   compat: 5
+  gsHWFixes:
+    halfPixelOffset: 1 # Fixes misaligned textures.
 SLUS-21628:
   name: "Hot Wheels - Beat That!"
   region: "NTSC-U"
@@ -46631,6 +46790,10 @@ SLUS-21781:
   name: "Guitar Hero - World Tour"
   region: "NTSC-U"
   compat: 5
+  speedHacks:
+    InstantVU1SpeedHack: 0 # Corrects note board position.
+  roundModes:
+    vuRoundMode: 0 # Fixes graphical issues ingame.
 SLUS-21782:
   name: "Shin Megami Tensei - Persona 4"
   region: "NTSC-U"
@@ -47817,11 +47980,12 @@ SLUS-29113:
   name: "Burnout 3 [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 3 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-29116:
   name: "WWE SmackDown! vs. RAW [Public Beta Vol.1.0]"
   region: "NTSC-U"
@@ -47921,11 +48085,12 @@ SLUS-29153:
   name: "Burnout Revenge [Demo]"
   region: "NTSC-U"
   clampModes:
-    vuClampMode: 0 # Fixes buggy lighting on certain objects.
+    vuClampMode: 0 # Fixes buggy lighting in the garage.
   gsHWFixes:
     halfPixelOffset: 2 # Fixes depth lines.
     autoFlush: 1 # Fixes blur.
     mipmap: 2 # Fixes over sharpening.
+    trilinearFiltering: 1 # Smoothes out mipmapping.
 SLUS-29154:
   name: "NHL '06 [Demo]"
   region: "NTSC-U"

--- a/bin/resources/shaders/dx11/tfx.fx
+++ b/bin/resources/shaders/dx11/tfx.fx
@@ -130,7 +130,6 @@ Texture2D<float4> Palette : register(t1);
 Texture2D<float4> RtTexture : register(t2);
 Texture2D<float> PrimMinTexture : register(t3);
 SamplerState TextureSampler : register(s0);
-SamplerState PaletteSampler : register(s1);
 
 #ifdef DX12
 cbuffer cb0 : register(b0)
@@ -207,9 +206,14 @@ float4 sample_c(float2 uv, float uv_w)
 #endif
 }
 
-float4 sample_p(float u)
+float4 sample_p(int u)
 {
-	return Palette.Sample(PaletteSampler, u);
+	return Palette.Load(int3(u, 0, 0));
+}
+
+float4 sample_p_norm(float u)
+{
+	return sample_p(int(u * 255.0f + 0.5f));
 }
 
 float4 clamp_wrap_uv(float4 uv)
@@ -278,7 +282,7 @@ float4x4 sample_4c(float4 uv, float uv_w)
 	return c;
 }
 
-float4 sample_4_index(float4 uv, float uv_w)
+int4 sample_4_index(float4 uv, float uv_w)
 {
 	float4 c;
 
@@ -293,20 +297,21 @@ float4 sample_4_index(float4 uv, float uv_w)
 	if (PS_PAL_FMT == 1)
 	{
 		// 4HL
-		c = float4(i & 0xFu) / 255.0f;
+		return int4(i & 0xFu);
 	}
 	else if (PS_PAL_FMT == 2)
 	{
 		// 4HH
-		c = float4(i >> 4u) / 255.0f;
+		return int4(i >> 4u);
 	}
-
-	// Most of texture will hit this code so keep normalized float value
-	// 8 bits
-	return c * 255./256 + 0.5/256;
+	else
+	{
+		// Not used
+		return int4(i);
+	}
 }
 
-float4x4 sample_4p(float4 u)
+float4x4 sample_4p(int4 u)
 {
 	float4x4 c;
 
@@ -468,7 +473,7 @@ float4 fetch_red(int2 xy)
 		rt = fetch_raw_color(xy);
 	}
 
-	return sample_p(rt.r) * 255.0f;
+	return sample_p_norm(rt.r) * 255.0f;
 }
 
 float4 fetch_green(int2 xy)
@@ -485,7 +490,7 @@ float4 fetch_green(int2 xy)
 		rt = fetch_raw_color(xy);
 	}
 
-	return sample_p(rt.g) * 255.0f;
+	return sample_p_norm(rt.g) * 255.0f;
 }
 
 float4 fetch_blue(int2 xy)
@@ -502,19 +507,19 @@ float4 fetch_blue(int2 xy)
 		rt = fetch_raw_color(xy);
 	}
 
-	return sample_p(rt.b) * 255.0f;
+	return sample_p_norm(rt.b) * 255.0f;
 }
 
 float4 fetch_alpha(int2 xy)
 {
 	float4 rt = fetch_raw_color(xy);
-	return sample_p(rt.a) * 255.0f;
+	return sample_p_norm(rt.a) * 255.0f;
 }
 
 float4 fetch_rgb(int2 xy)
 {
 	float4 rt = fetch_raw_color(xy);
-	float4 c = float4(sample_p(rt.r).r, sample_p(rt.g).g, sample_p(rt.b).b, 1.0);
+	float4 c = float4(sample_p_norm(rt.r).r, sample_p_norm(rt.g).g, sample_p_norm(rt.b).b, 1.0);
 	return c * 255.0f;
 }
 

--- a/xbsx2/Achievements.h
+++ b/xbsx2/Achievements.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "common/Xbsx2Types.h"
+#include <vector>
+
+namespace Achievements
+{
+#ifdef ENABLE_ACHIEVEMENTS
+
+	// Implemented in Host.
+	extern bool Reset();
+	extern void LoadState(const u8* state_data, u32 state_data_size);
+	extern std::vector<u8> SaveState();
+	extern void GameChanged(u32 crc);
+
+	/// Re-enables hardcode mode if it is enabled in the settings.
+	extern void ResetChallengeMode();
+
+	/// Forces hardcore mode off until next reset.
+	extern void DisableChallengeMode();
+
+	/// Prompts the user to disable hardcore mode, if they agree, returns true.
+	extern bool ConfirmChallengeModeDisable(const char* trigger);
+
+	/// Returns true if features such as save states should be disabled.
+	extern bool ChallengeModeActive();
+
+#else
+
+	// Make noops when compiling without cheevos.
+	static inline bool Reset()
+	{
+		return true;
+	}
+	static inline void LoadState(const u8* state_data, u32 state_data_size)
+	{
+	}
+	static inline std::vector<u8> SaveState()
+	{
+		return {};
+	}
+	static inline void GameChanged()
+	{
+	}
+
+	static constexpr inline bool ChallengeModeActive()
+	{
+		return false;
+	}
+
+	static inline void ResetChallengeMode() {}
+
+	static inline void DisableChallengeMode() {}
+
+	static inline bool ConfirmChallengeModeDisable(const char* trigger)
+	{
+		return true;
+	}
+
+#endif
+} // namespace Achievements

--- a/xbsx2/Config.h
+++ b/xbsx2/Config.h
@@ -470,6 +470,7 @@ struct Xbsx2Config
 					OsdShowIndicators : 1;
 
 				bool
+					AccurateDATE : 1,
 					GPUPaletteConversion : 1,
 					AutoFlushSW : 1,
 					PreloadFrameWithGSData : 1,
@@ -621,7 +622,6 @@ struct Xbsx2Config
 			NoSync,
 		};
 
-
 		BITFIELD32()
 		bool
 			AdvancedVolumeControl : 1;
@@ -631,7 +631,7 @@ struct Xbsx2Config
 		SynchronizationMode SynchMode = SynchronizationMode::TimeStretch;
 
 		s32 FinalVolume = 100;
-		s32 Latency{100};
+		s32 Latency{64};
 		s32 SpeakerConfiguration{0};
 
 		float VolumeAdjustC{ 0.0f };
@@ -644,6 +644,7 @@ struct Xbsx2Config
 		float VolumeAdjustLFE{ 0.0f };
 
 		std::string OutputModule;
+		std::string BackendName;
 
 		SPU2Options();
 
@@ -653,23 +654,24 @@ struct Xbsx2Config
 		{
 			return OpEqu(bitset) &&
 
-				OpEqu(Interpolation) &&
-				OpEqu(SynchMode) &&
+				   OpEqu(Interpolation) &&
+				   OpEqu(SynchMode) &&
 
-				OpEqu(FinalVolume) &&
-				OpEqu(Latency) &&
-				OpEqu(SpeakerConfiguration) &&
+				   OpEqu(FinalVolume) &&
+				   OpEqu(Latency) &&
+				   OpEqu(SpeakerConfiguration) &&
 
-				OpEqu(VolumeAdjustC) &&
-				OpEqu(VolumeAdjustFL) &&
-				OpEqu(VolumeAdjustFR) &&
-				OpEqu(VolumeAdjustBL) &&
-				OpEqu(VolumeAdjustBR) &&
-				OpEqu(VolumeAdjustSL) &&
-				OpEqu(VolumeAdjustSR) &&
-				OpEqu(VolumeAdjustLFE) &&
+				   OpEqu(VolumeAdjustC) &&
+				   OpEqu(VolumeAdjustFL) &&
+				   OpEqu(VolumeAdjustFR) &&
+				   OpEqu(VolumeAdjustBL) &&
+				   OpEqu(VolumeAdjustBR) &&
+				   OpEqu(VolumeAdjustSL) &&
+				   OpEqu(VolumeAdjustSR) &&
+				   OpEqu(VolumeAdjustLFE) &&
 
-				OpEqu(OutputModule);
+				   OpEqu(OutputModule) &&
+				   OpEqu(BackendName);
 		}
 
 		bool operator!=(const SPU2Options& right) const

--- a/xbsx2/Frontend/FullscreenUI.cpp
+++ b/xbsx2/Frontend/FullscreenUI.cpp
@@ -57,6 +57,9 @@
 #include <bitset>
 #include <thread>
 
+// #ifdef ENABLE_ACHIEVEMENTS
+// #include "Frontend/Achievements.h"
+// #endif
 static constexpr s32 MAX_SAVE_STATE_SLOTS = 10;
 
 using ImGuiFullscreen::g_large_font;
@@ -145,13 +148,20 @@ namespace FullscreenUI
 		Landing,
 		GameList,
 		Settings,
-		PauseMenu
+		PauseMenu,
+		// #ifdef ENABLE_ACHIEVEMENTS
+		// 		Achievements,
+		// 		Leaderboards,
+		// #endif
 	};
 
 	enum class PauseSubMenu
 	{
 		None,
 		Exit,
+		// #ifdef ENABLE_ACHIEVEMENTS
+		// 		Achievements,
+		// #endif
 	};
 
 	enum class SettingsPage
@@ -166,7 +176,9 @@ namespace FullscreenUI
 		MemoryCard,
 		Controller,
 		Hotkey,
-		// Achievements,
+		// #ifdef ENABLE_ACHIEVEMENTS
+		// 		Achievements,
+		// #endif
 		Directory,
 		Advanced,
 		GameFixes,
@@ -185,10 +197,6 @@ namespace FullscreenUI
 	// Utility
 	//////////////////////////////////////////////////////////////////////////
 	static std::string TimeToPrintableString(time_t t);
-	static void StartAsyncOp(std::function<void(::ProgressCallback*)> callback, std::string name);
-	static void AsyncOpThreadEntryPoint(std::function<void(::ProgressCallback*)> callback, FullscreenUI::ProgressCallback* progress);
-	static void CancelAsyncOpWithName(const std::string_view& name);
-	static void CancelAsyncOps();
 
 	//////////////////////////////////////////////////////////////////////////
 	// Main
@@ -216,11 +224,6 @@ namespace FullscreenUI
 	static bool s_pause_menu_was_open = false;
 	static bool s_was_paused_on_quick_menu_open = false;
 	static bool s_about_window_open = false;
-
-	// async operations (e.g. cover downloads)
-	using AsyncOpEntry = std::pair<std::thread, std::unique_ptr<FullscreenUI::ProgressCallback>>;
-	static std::mutex s_async_op_mutex;
-	static std::deque<AsyncOpEntry> s_async_ops;
 
 	// local copies of the currently-running game
 	static std::string s_current_game_title;
@@ -287,7 +290,10 @@ namespace FullscreenUI
 	static void DrawCreateMemoryCardWindow();
 	static void DrawControllerSettingsPage();
 	static void DrawHotkeySettingsPage();
-	//  static void DrawAchievementsSettingsPage();
+	// #ifdef ENABLE_ACHIEVEMENTS
+	// 	static void DrawAchievementsSettingsPage();
+	// 	static void DrawAchievementsLoginWindow();
+	// #endif
 	static void DrawDirectorySettingsPage();
 	static void DrawAdvancedSettingsPage();
 	static void DrawGameFixesSettingsPage();
@@ -414,6 +420,20 @@ namespace FullscreenUI
 	static std::unordered_map<std::string, std::string> s_cover_image_map;
 	static std::vector<const GameList::Entry*> s_game_list_sorted_entries;
 	static GameListPage s_game_list_page = GameListPage::Grid;
+
+	// #ifdef ENABLE_ACHIEVEMENTS
+	// 	//////////////////////////////////////////////////////////////////////////
+	// 	// Achievements
+	// 	//////////////////////////////////////////////////////////////////////////
+	// 	static void DrawAchievementsWindow();
+	// 	static void DrawAchievement(const Achievements::Achievement& cheevo);
+	// 	static void DrawLeaderboardsWindow();
+	// 	static void DrawLeaderboardListEntry(const Achievements::Leaderboard& lboard);
+	// 	static void DrawLeaderboardEntry(
+	// 		const Achievements::LeaderboardEntry& lbEntry, float rank_column_width, float name_column_width, float column_spacing);
+	//
+	// 	static std::optional<u32> s_open_leaderboard_id;
+	// #endif
 } // namespace FullscreenUI
 
 //////////////////////////////////////////////////////////////////////////
@@ -432,75 +452,6 @@ std::string FullscreenUI::TimeToPrintableString(time_t t)
 	char buf[256];
 	std::strftime(buf, sizeof(buf), "%c", &lt);
 	return std::string(buf);
-}
-
-void FullscreenUI::StartAsyncOp(std::function<void(::ProgressCallback*)> callback, std::string name)
-{
-	CancelAsyncOpWithName(name);
-
-	std::unique_lock lock(s_async_op_mutex);
-	std::unique_ptr<FullscreenUI::ProgressCallback> progress(std::make_unique<FullscreenUI::ProgressCallback>(std::move(name)));
-	std::thread thread(AsyncOpThreadEntryPoint, std::move(callback), progress.get());
-	s_async_ops.emplace_back(std::move(thread), std::move(progress));
-}
-
-void FullscreenUI::CancelAsyncOpWithName(const std::string_view& name)
-{
-	std::unique_lock lock(s_async_op_mutex);
-	for (auto iter = s_async_ops.begin(); iter != s_async_ops.end(); ++iter)
-	{
-		if (name != iter->second->GetName())
-			continue;
-
-		// move the thread out so it doesn't detach itself, then join
-		std::unique_ptr<FullscreenUI::ProgressCallback> progress(std::move(iter->second));
-		std::thread thread(std::move(iter->first));
-		progress->SetCancelled();
-		s_async_ops.erase(iter);
-		lock.unlock();
-		if (thread.joinable())
-			thread.join();
-		lock.lock();
-		break;
-	}
-}
-
-void FullscreenUI::CancelAsyncOps()
-{
-	std::unique_lock lock(s_async_op_mutex);
-	while (!s_async_ops.empty())
-	{
-		auto iter = s_async_ops.begin();
-
-		// move the thread out so it doesn't detach itself, then join
-		std::unique_ptr<FullscreenUI::ProgressCallback> progress(std::move(iter->second));
-		std::thread thread(std::move(iter->first));
-		progress->SetCancelled();
-		s_async_ops.erase(iter);
-		lock.unlock();
-		if (thread.joinable())
-			thread.join();
-		lock.lock();
-	}
-}
-
-void FullscreenUI::AsyncOpThreadEntryPoint(std::function<void(::ProgressCallback*)> callback, FullscreenUI::ProgressCallback* progress)
-{
-	Threading::SetNameOfCurrentThread(fmt::format("{} Async Op", progress->GetName()).c_str());
-
-	callback(progress);
-
-	// if we were removed from the list, it means we got cancelled, and the main thread is blocking
-	std::unique_lock lock(s_async_op_mutex);
-	for (auto iter = s_async_ops.begin(); iter != s_async_ops.end(); ++iter)
-	{
-		if (iter->second.get() == progress)
-		{
-			iter->first.detach();
-			s_async_ops.erase(iter);
-			break;
-		}
-	}
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -708,7 +659,6 @@ void FullscreenUI::OpenPauseSubMenu(PauseSubMenu submenu)
 
 void FullscreenUI::Shutdown()
 {
-	CancelAsyncOps();
 	CloseSaveStateSelector();
 	s_cover_image_map.clear();
 	s_game_list_sorted_entries = {};
@@ -753,6 +703,14 @@ void FullscreenUI::Render()
 		case MainWindowType::PauseMenu:
 			DrawPauseMenu(s_current_main_window);
 			break;
+			// #ifdef ENABLE_ACHIEVEMENTS
+			// 		case MainWindowType::Achievements:
+			// 			DrawAchievementsWindow();
+			// 			break;
+			// 		case MainWindowType::Leaderboards:
+			// 			DrawLeaderboardsWindow();
+			// 			break;
+			// #endif
 		default:
 			break;
 	}
@@ -842,7 +800,7 @@ void FullscreenUI::DestroyResources()
 
 ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetDiscImageFilters()
 {
-	return {"*.bin", "*.iso", "*.cue", "*.chd", "*.cso", "*.gz", "*.elf", "*.irx", "*.m3u", "*.gs", "*.gs.xz", "*.gs.zst"};
+	return {"*.bin", "*.iso", "*.cue", "*.chd", "*.cso", "*.gz", "*.elf", "*.irx", "*.gs", "*.gs.xz", "*.gs.zst", "*.gs.dump"};
 }
 
 void FullscreenUI::DoStartPath(const std::string& path, std::optional<s32> state_index, std::optional<bool> fast_boot)
@@ -860,7 +818,7 @@ void FullscreenUI::DoStartPath(const std::string& path, std::optional<s32> state
 		if (VMManager::HasValidVM())
 			return;
 
-		if (VMManager::Initialize(params))
+		if (VMManager::Initialize(std::move(params)))
 			VMManager::SetState(VMState::Running);
 		else
 			s_current_main_window = prev_window;
@@ -887,7 +845,7 @@ void FullscreenUI::DoStartBIOS()
 			return;
 
 		VMBootParameters params;
-		if (VMManager::Initialize(params))
+		if (VMManager::Initialize(std::move(params)))
 			VMManager::SetState(VMState::Running);
 		else
 			SwitchToLanding();
@@ -941,6 +899,7 @@ void FullscreenUI::DoStartDisc()
 	});
 }
 #endif
+
 void FullscreenUI::DoToggleFrameLimit()
 {
 	Host::RunOnCPUThread([]() {
@@ -1335,12 +1294,6 @@ void FullscreenUI::DrawIntListSetting(SettingsInterface* bsi, const char* title,
 	int default_value, const char* const* options, size_t option_count, int option_offset, bool enabled, float height, ImFont* font,
 	ImFont* summary_font)
 {
-	if (options && option_count == 0)
-	{
-		while (options[option_count] != nullptr)
-			option_count++;
-	}
-
 	const bool game_settings = IsEditingGameSettings(bsi);
 	const std::optional<int> value =
 		bsi->GetOptionalIntValue(section, key, game_settings ? std::nullopt : std::optional<int>(default_value));
@@ -2038,9 +1991,11 @@ void FullscreenUI::DrawSettingsWindow()
 				DrawHotkeySettingsPage();
 				break;
 
-				/*  case SettingsPage::Achievements:
-				DrawAchievementsSettingsPage();
-				break;  */
+				// #ifdef ENABLE_ACHIEVEMENTS
+				// 			case SettingsPage::Achievements:
+				// 				DrawAchievementsSettingsPage();
+				// 				break;
+				// #endif
 
 			case SettingsPage::Directory:
 				DrawDirectorySettingsPage();
@@ -2151,11 +2106,6 @@ void FullscreenUI::DrawInterfaceSettingsPage()
 		"Shows indicators when fast forwarding, pausing, and other abnormal states are active.", "EmuCore/GS", "OsdShowIndicators", true);
 
 	MenuHeading("Behaviour");
-
-#ifdef WITH_DISCORD_PRESENCE
-	DrawToggleSetting("Enable Discord Presence", "Shows the game you are currently playing as part of your profile on Discord.", "UI",
-		"DiscordPresence", false);
-#endif
 	DrawToggleSetting(bsi, ICON_FA_WINDOW_MAXIMIZE " Pause On Menu",
 		"Pauses the emulator when you open the quick menu, and unpauses when you close it.", "UI", "PauseOnMenu", true);
 	MenuHeading("Operations");
@@ -2562,6 +2512,8 @@ void FullscreenUI::DrawEnhancementsSettingsPage()
 			std::size(s_preloading_options));
 		DrawIntListSetting(bsi, "Hardware Download Mode", "Changes synchronization behavior for GS downloads.", "EmuCore/GS", "HWDownloadMode",
 			static_cast<int>(GSHardwareDownloadMode::Enabled), s_hw_download, std::size(s_hw_download));
+		DrawToggleSetting(bsi, "Accurate Destination Alpha Test", "Implement a more accurate algorithm to compute GS destination alpha testing.",
+			"EmuCore/GS", "accurate_date", true);
 		DrawToggleSetting(bsi, "Conservative Buffer Allocation",
 			"Uses a smaller framebuffer where possible to reduce VRAM bandwidth and usage. May need to be disabled to prevent FMV "
 			"flicker.",
@@ -2739,7 +2691,7 @@ void FullscreenUI::DrawAudioSettingsPage()
 
 	MenuHeading("Runtime Settings");
 	DrawIntRangeSetting(bsi, ICON_FA_VOLUME_UP " Output Volume", "Applies a global volume modifier to all sound produced by the game.",
-		"SPU2/Mixing", "FinalVolume", 100, 0, 100, "%d%%");
+		"SPU2/Mixing", "FinalVolume", 100, 0, 200, "%d%%");
 
 	MenuHeading("Mixing Settings");
 	DrawIntListSetting(bsi, ICON_FA_MUSIC " Interpolation Mode", "Determines how ADPCM samples are interpolated to the target pitch.",
@@ -3106,10 +3058,12 @@ void FullscreenUI::DrawControllerSettingsPage()
 			ResetControllerSettings();
 	}
 
-	//  if (MenuButton(ICON_FA_FOLDER_OPEN " Load Profile", "Replaces these settings with a previously saved input profile."))
-	//  	DoLoadInputProfile();
-	//  if (MenuButton(ICON_FA_SAVE " Save Profile", "Stores the current settings to an input profile."))
-	//  	DoSaveInputProfile();
+#ifndef _UWP // Not currently working.
+	if (MenuButton(ICON_FA_FOLDER_OPEN " Load Profile", "Replaces these settings with a previously saved input profile."))
+		DoLoadInputProfile();
+	if (MenuButton(ICON_FA_SAVE " Save Profile", "Stores the current settings to an input profile."))
+		DoSaveInputProfile();
+#endif
 
 #ifndef _UWP
 
@@ -3370,7 +3324,7 @@ void FullscreenUI::DrawHotkeySettingsPage()
 
 	EndMenuButtons();
 }
-
+// #ifdef ENABLE_ACHIEVEMENTS
 //  void FullscreenUI::DrawAchievementsSettingsPage()
 //  {
 //
@@ -3379,8 +3333,8 @@ void FullscreenUI::DrawHotkeySettingsPage()
 //  		ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
 //  	EndMenuButtons();
 //  }
+// #endif
 
-// Custom Directory Settings Tab
 void FullscreenUI::DrawDirectorySettingsPage()
 {
 	SettingsInterface* bsi = GetEditingSettingsInterface();
@@ -3563,6 +3517,9 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 		static constexpr u32 submenu_item_count[] = {
 			10, // None
 			3, // Exit
+			// #ifdef ENABLE_ACHIEVEMENTS
+			// 			3, // Achievements
+			// #endif
 		};
 
 		const bool just_focused = ResetFocusHere();
@@ -3635,19 +3592,30 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 				if (ActiveButton(ICON_FA_COG " Global Settings", false))
 					SwitchToSettings();
 			}
+			// #ifdef ENABLE_ACHIEVEMENTS
+			// 				if (ActiveButton(ICON_FA_TROPHY " Achievements", false,
+			// 						Achievements::HasActiveGame() && Achievements::SafeHasAchievementsOrLeaderboards()))
+			// 				{
+			// 					const auto lock = Achievements::GetLock();
+			//
+			// 					// skip second menu and go straight to cheevos if there's no lbs
+			// 					if (Achievements::GetLeaderboardCount() == 0)
+			// 						OpenAchievementsWindow();
+			// 					else
+			// 						OpenPauseSubMenu(PauseSubMenu::Achievements);
+			// 				}
+			// #endif
 			break;
 
 			case PauseSubMenu::Exit:
 			{
 				if (just_focused)
-					ImGui::SetFocusID(ImGui::GetID(ICON_FA_POWER_OFF " Exit Without Saving"), ImGui::GetCurrentWindow());
+					ImGui::SetFocusID(ImGui::GetID(ICON_FA_SIGN_OUT_ALT " Exit Without Saving"), ImGui::GetCurrentWindow());
 
 				if (ActiveButton(ICON_FA_BACKWARD " Back To Pause Menu", false))
 				{
 					OpenPauseSubMenu(PauseSubMenu::None);
 				}
-
-
 
 				if (ActiveButton(ICON_FA_SAVE " Exit And Save State", false))
 					DoShutdown(true);
@@ -3656,6 +3624,20 @@ void FullscreenUI::DrawPauseMenu(MainWindowType type)
 					DoShutdown(false);
 			}
 			break;
+//  #ifdef ENABLE_ACHIEVEMENTS
+//  			case PauseSubMenu::Achievements:
+//  			{
+//  				if (ActiveButton(ICON_FA_BACKWARD " Back To Pause Menu", false))
+//  					OpenPauseSubMenu(PauseSubMenu::None);
+//
+//  				if (ActiveButton(ICON_FA_TROPHY " Achievements", false))
+//  					OpenAchievementsWindow();
+//
+//  				if (ActiveButton(ICON_FA_STOPWATCH " Leaderboards", false))
+//  					OpenLeaderboardsWindow();
+//  			}
+//  			break;
+//  #endif
 		}
 
 		EndMenuButtons();
@@ -4011,7 +3993,7 @@ void FullscreenUI::DoLoadState(std::string path)
 			VMBootParameters params;
 			params.filename = std::move(boot_path);
 			params.save_state = std::move(path);
-			if (VMManager::Initialize(params))
+			if (VMManager::Initialize(std::move(params)))
 				VMManager::SetState(VMState::Running);
 		}
 	});
@@ -4113,6 +4095,7 @@ void FullscreenUI::DrawGameList(const ImVec2& heading_size)
 	if (BeginFullscreenColumnWindow(0.0f, -530.0f, "game_list_entries"))
 	{
 		const ImVec2 image_size(LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT * 1.00f, LAYOUT_MENU_BUTTON_HEIGHT));
+		ResetFocusHere();
 
 		BeginMenuButtons();
 
@@ -4835,3 +4818,787 @@ void FullscreenUI::ProgressCallback::SetCancelled()
 	if (m_cancellable)
 		m_cancelled = true;
 }
+
+// #ifdef ENABLE_ACHIEVEMENTS
+//
+// bool FullscreenUI::OpenAchievementsWindow()
+// {
+// 	if (!VMManager::HasValidVM() || !Initialize())
+// 		return false;
+//
+// 	if (!Achievements::HasActiveGame() || Achievements::GetAchievementCount() == 0)
+// 	{
+// 		ShowToast(std::string(), "This game has no achievements.");
+// 		return false;
+// 	}
+//
+// 	if (s_current_main_window != MainWindowType::PauseMenu)
+// 		PauseForMenuOpen();
+//
+// 	s_current_main_window = MainWindowType::Achievements;
+// 	QueueResetFocus();
+// 	return true;
+// }
+//
+// void FullscreenUI::DrawAchievement(const Achievements::Achievement& cheevo)
+// {
+// 	static constexpr float alpha = 0.8f;
+// 	static constexpr float progress_height_unscaled = 20.0f;
+// 	static constexpr float progress_spacing_unscaled = 5.0f;
+//
+// 	std::string id_str(fmt::format("chv_{}", cheevo.id));
+//
+// 	const auto progress = Achievements::GetAchievementProgress(cheevo);
+// 	const bool is_measured = progress.second != 0;
+//
+// 	ImRect bb;
+// 	bool visible, hovered;
+// 	bool pressed = MenuButtonFrame(id_str.c_str(), true,
+// 		!is_measured ? LAYOUT_MENU_BUTTON_HEIGHT : LAYOUT_MENU_BUTTON_HEIGHT + progress_height_unscaled + progress_spacing_unscaled,
+// 		&visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+// 	if (!visible)
+// 		return;
+//
+// 	const ImVec2 image_size(LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT, LAYOUT_MENU_BUTTON_HEIGHT));
+// 	const std::string& badge_path = Achievements::GetAchievementBadgePath(cheevo);
+// 	if (!badge_path.empty())
+// 	{
+// 		HostDisplayTexture* badge = GetCachedTextureAsync(badge_path.c_str());
+// 		if (badge)
+// 		{
+// 			ImGui::GetWindowDrawList()->AddImage(
+// 				badge->GetHandle(), bb.Min, bb.Min + image_size, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
+// 		}
+// 	}
+//
+// 	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+// 	const float text_start_x = bb.Min.x + image_size.x + LayoutScale(15.0f);
+// 	const ImRect title_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 	const ImRect summary_bb(ImVec2(text_start_x, midpoint), bb.Max);
+//
+// 	ImGui::PushFont(g_large_font);
+// 	ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, cheevo.title.c_str(), cheevo.title.c_str() + cheevo.title.size(), nullptr,
+// 		ImVec2(0.0f, 0.0f), &title_bb);
+// 	ImGui::PopFont();
+//
+// 	if (!cheevo.description.empty())
+// 	{
+// 		ImGui::PushFont(g_medium_font);
+// 		ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, cheevo.description.c_str(),
+// 			cheevo.description.c_str() + cheevo.description.size(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+// 		ImGui::PopFont();
+// 	}
+//
+// 	if (is_measured)
+// 	{
+// 		ImDrawList* dl = ImGui::GetWindowDrawList();
+// 		const float progress_height = LayoutScale(progress_height_unscaled);
+// 		const float progress_spacing = LayoutScale(progress_spacing_unscaled);
+// 		const float top = midpoint + g_medium_font->FontSize + progress_spacing;
+// 		const ImRect progress_bb(ImVec2(text_start_x, top), ImVec2(bb.Max.x, top + progress_height));
+// 		const float fraction = static_cast<float>(progress.first) / static_cast<float>(progress.second);
+// 		dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
+// 		dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
+// 			ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
+//
+// 		const std::string text(Achievements::GetAchievementProgressText(cheevo));
+// 		const ImVec2 text_size = ImGui::CalcTextSize(text.c_str());
+// 		const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
+// 			progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
+// 		dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor), text.c_str(),
+// 			text.c_str() + text.size());
+// 	}
+//
+// #if 0
+// 	// The API doesn't seem to send us this :(
+// 	if (!cheevo.locked)
+// 	{
+// 		ImGui::PushFont(g_medium_font);
+//
+// 		const ImRect time_bb(ImVec2(text_start_x, bb.Min.y),
+// 			ImVec2(bb.Max.x, bb.Min.y + g_medium_font->FontSize + LayoutScale(4.0f)));
+// 		text.Format("Unlocked 21 Feb, 2019 @ 3:14am");
+// 		ImGui::RenderTextClipped(time_bb.Min, time_bb.Max, text.GetCharArray(), text.GetCharArray() + text.GetLength(),
+// 			nullptr, ImVec2(1.0f, 0.0f), &time_bb);
+// 		ImGui::PopFont();
+// 	}
+// #endif
+//
+// 	if (pressed)
+// 	{
+// 		// TODO: What should we do here?
+// 		// Display information or something..
+// 	}
+// }
+//
+// void FullscreenUI::DrawAchievementsWindow()
+// {
+// 	// ensure image downloads still happen while we're paused
+// 	Achievements::ProcessPendingHTTPRequestsFromGSThread();
+//
+// 	static constexpr float alpha = 0.8f;
+// 	static constexpr float heading_height_unscaled = 110.0f;
+//
+// 	ImGui::SetNextWindowBgAlpha(alpha);
+//
+// 	const ImVec4 background(0.13f, 0.13f, 0.13f, alpha);
+// 	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
+// 	const float heading_height = LayoutScale(heading_height_unscaled);
+//
+// 	if (BeginFullscreenWindow(ImVec2(0.0f, 0.0f), ImVec2(display_size.x, heading_height), "achievements_heading", background, 0.0f, 0.0f,
+// 			ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse))
+// 	{
+// 		auto lock = Achievements::GetLock();
+//
+// 		ImRect bb;
+// 		bool visible, hovered;
+// 		/*bool pressed = */ MenuButtonFrame(
+// 			"achievements_heading", false, heading_height_unscaled, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+//
+// 		if (visible)
+// 		{
+// 			const float padding = LayoutScale(10.0f);
+// 			const float spacing = LayoutScale(10.0f);
+// 			const float image_height = LayoutScale(85.0f);
+//
+// 			const ImVec2 icon_min(bb.Min + ImVec2(padding, padding));
+// 			const ImVec2 icon_max(icon_min + ImVec2(image_height, image_height));
+//
+// 			const std::string& icon_path = Achievements::GetGameIcon();
+// 			if (!icon_path.empty())
+// 			{
+// 				HostDisplayTexture* badge = GetCachedTexture(icon_path.c_str());
+// 				if (badge)
+// 				{
+// 					ImGui::GetWindowDrawList()->AddImage(
+// 						badge->GetHandle(), icon_min, icon_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
+// 				}
+// 			}
+//
+// 			float left = bb.Min.x + padding + image_height + spacing;
+// 			float right = bb.Max.x - padding;
+// 			float top = bb.Min.y + padding;
+// 			ImDrawList* dl = ImGui::GetWindowDrawList();
+// 			std::string text;
+// 			ImVec2 text_size;
+//
+// 			const u32 unlocked_count = Achievements::GetUnlockedAchiementCount();
+// 			const u32 achievement_count = Achievements::GetAchievementCount();
+// 			const u32 current_points = Achievements::GetCurrentPointsForGame();
+// 			const u32 total_points = Achievements::GetMaximumPointsForGame();
+//
+// 			if (FloatingButton(ICON_FA_WINDOW_CLOSE, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) || WantsToCloseMenu())
+// 			{
+// 				ReturnToMainWindow();
+// 			}
+//
+// 			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
+// 			text = Achievements::GetGameTitle();
+//
+// 			if (Achievements::ChallengeModeActive())
+// 				text += " (Hardcore Mode)";
+//
+// 			top += g_large_font->FontSize + spacing;
+//
+// 			ImGui::PushFont(g_large_font);
+// 			ImGui::RenderTextClipped(
+// 				title_bb.Min, title_bb.Max, text.c_str(), text.c_str() + text.length(), nullptr, ImVec2(0.0f, 0.0f), &title_bb);
+// 			ImGui::PopFont();
+//
+// 			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+// 			if (unlocked_count == achievement_count)
+// 			{
+// 				text = fmt::format("You have unlocked all achievements and earned {} points!", total_points);
+// 			}
+// 			else
+// 			{
+// 				text = fmt::format("You have unlocked {} of {} achievements, earning {} of {} possible points.", unlocked_count,
+// 					achievement_count, current_points, total_points);
+// 			}
+//
+// 			top += g_medium_font->FontSize + spacing;
+//
+// 			ImGui::PushFont(g_medium_font);
+// 			ImGui::RenderTextClipped(
+// 				summary_bb.Min, summary_bb.Max, text.c_str(), text.c_str() + text.length(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+// 			ImGui::PopFont();
+//
+// 			const float progress_height = LayoutScale(20.0f);
+// 			const ImRect progress_bb(ImVec2(left, top), ImVec2(right, top + progress_height));
+// 			const float fraction = static_cast<float>(unlocked_count) / static_cast<float>(achievement_count);
+// 			dl->AddRectFilled(progress_bb.Min, progress_bb.Max, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryDarkColor));
+// 			dl->AddRectFilled(progress_bb.Min, ImVec2(progress_bb.Min.x + fraction * progress_bb.GetWidth(), progress_bb.Max.y),
+// 				ImGui::GetColorU32(ImGuiFullscreen::UISecondaryColor));
+//
+// 			text = fmt::format("{}%", static_cast<int>(std::round(fraction * 100.0f)));
+// 			text_size = ImGui::CalcTextSize(text.c_str());
+// 			const ImVec2 text_pos(progress_bb.Min.x + ((progress_bb.Max.x - progress_bb.Min.x) / 2.0f) - (text_size.x / 2.0f),
+// 				progress_bb.Min.y + ((progress_bb.Max.y - progress_bb.Min.y) / 2.0f) - (text_size.y / 2.0f));
+// 			dl->AddText(g_medium_font, g_medium_font->FontSize, text_pos, ImGui::GetColorU32(ImGuiFullscreen::UIPrimaryTextColor),
+// 				text.c_str(), text.c_str() + text.length());
+// 			top += progress_height + spacing;
+// 		}
+// 	}
+// 	EndFullscreenWindow();
+//
+// 	ImGui::SetNextWindowBgAlpha(alpha);
+//
+// 	if (BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height), "achievements",
+// 			background, 0.0f, 0.0f, 0))
+// 	{
+// 		BeginMenuButtons();
+//
+// 		static bool unlocked_achievements_collapsed = false;
+//
+// 		unlocked_achievements_collapsed ^=
+// 			MenuHeadingButton("Unlocked Achievements", unlocked_achievements_collapsed ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_UP);
+// 		if (!unlocked_achievements_collapsed)
+// 		{
+// 			Achievements::EnumerateAchievements([](const Achievements::Achievement& cheevo) -> bool {
+// 				if (!cheevo.locked)
+// 					DrawAchievement(cheevo);
+//
+// 				return true;
+// 			});
+// 		}
+//
+// 		if (Achievements::GetUnlockedAchiementCount() != Achievements::GetAchievementCount())
+// 		{
+// 			static bool locked_achievements_collapsed = false;
+// 			locked_achievements_collapsed ^=
+// 				MenuHeadingButton("Locked Achievements", locked_achievements_collapsed ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_UP);
+// 			if (!locked_achievements_collapsed)
+// 			{
+// 				Achievements::EnumerateAchievements([](const Achievements::Achievement& cheevo) -> bool {
+// 					if (cheevo.locked)
+// 						DrawAchievement(cheevo);
+//
+// 					return true;
+// 				});
+// 			}
+// 		}
+//
+// 		EndMenuButtons();
+// 	}
+// 	EndFullscreenWindow();
+// }
+//
+// bool FullscreenUI::OpenLeaderboardsWindow()
+// {
+// 	if (!VMManager::HasValidVM() || !Initialize())
+// 		return false;
+//
+// 	if (!Achievements::HasActiveGame() || Achievements::GetLeaderboardCount() == 0)
+// 	{
+// 		ShowToast(std::string(), "This game has no leaderboards.");
+// 		return false;
+// 	}
+//
+// 	if (s_current_main_window != MainWindowType::PauseMenu)
+// 		PauseForMenuOpen();
+//
+// 	s_current_main_window = MainWindowType::Leaderboards;
+// 	s_open_leaderboard_id.reset();
+// 	QueueResetFocus();
+// 	return true;
+// }
+//
+//
+// void FullscreenUI::DrawLeaderboardListEntry(const Achievements::Leaderboard& lboard)
+// {
+// 	static constexpr float alpha = 0.8f;
+//
+// 	std::string id_str(fmt::format("lb_{}", lboard.id));
+//
+// 	ImRect bb;
+// 	bool visible, hovered;
+// 	bool pressed = MenuButtonFrame(id_str.c_str(), true, LAYOUT_MENU_BUTTON_HEIGHT, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+// 	if (!visible)
+// 		return;
+//
+// 	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+// 	const float text_start_x = bb.Min.x + LayoutScale(15.0f);
+// 	const ImRect title_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 	const ImRect summary_bb(ImVec2(text_start_x, midpoint), bb.Max);
+//
+// 	ImGui::PushFont(g_large_font);
+// 	ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, lboard.title.c_str(), lboard.title.c_str() + lboard.title.size(), nullptr,
+// 		ImVec2(0.0f, 0.0f), &title_bb);
+// 	ImGui::PopFont();
+//
+// 	if (!lboard.description.empty())
+// 	{
+// 		ImGui::PushFont(g_medium_font);
+// 		ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, lboard.description.c_str(),
+// 			lboard.description.c_str() + lboard.description.size(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+// 		ImGui::PopFont();
+// 	}
+//
+// 	if (pressed)
+// 	{
+// 		s_open_leaderboard_id = lboard.id;
+// 	}
+// }
+//
+// void FullscreenUI::DrawLeaderboardEntry(
+// 	const Achievements::LeaderboardEntry& lbEntry, float rank_column_width, float name_column_width, float column_spacing)
+// {
+// 	static constexpr float alpha = 0.8f;
+//
+// 	ImRect bb;
+// 	bool visible, hovered;
+// 	bool pressed =
+// 		MenuButtonFrame(lbEntry.user.c_str(), true, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+// 	if (!visible)
+// 		return;
+//
+// 	const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+// 	float text_start_x = bb.Min.x + LayoutScale(15.0f);
+// 	std::string rank_str(fmt::format("{}", lbEntry.rank));
+//
+// 	ImGui::PushFont(g_large_font);
+// 	if (lbEntry.is_self)
+// 	{
+// 		ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 242, 0, 255));
+// 	}
+//
+// 	const ImRect rank_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 	ImGui::RenderTextClipped(rank_bb.Min, rank_bb.Max, rank_str.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &rank_bb);
+// 	text_start_x += rank_column_width + column_spacing;
+//
+// 	const ImRect user_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 	ImGui::RenderTextClipped(
+// 		user_bb.Min, user_bb.Max, lbEntry.user.c_str(), lbEntry.user.c_str() + lbEntry.user.size(), nullptr, ImVec2(0.0f, 0.0f), &user_bb);
+// 	text_start_x += name_column_width + column_spacing;
+//
+// 	const ImRect score_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 	ImGui::RenderTextClipped(score_bb.Min, score_bb.Max, lbEntry.formatted_score.c_str(),
+// 		lbEntry.formatted_score.c_str() + lbEntry.formatted_score.size(), nullptr, ImVec2(0.0f, 0.0f), &score_bb);
+//
+// 	if (lbEntry.is_self)
+// 	{
+// 		ImGui::PopStyleColor();
+// 	}
+//
+// 	ImGui::PopFont();
+//
+// 	// This API DOES list the submission date/time, but is it relevant?
+// #if 0
+// 	if (!cheevo.locked)
+// 	{
+// 		ImGui::PushFont(g_medium_font);
+//
+// 		const ImRect time_bb(ImVec2(text_start_x, bb.Min.y),
+// 			ImVec2(bb.Max.x, bb.Min.y + g_medium_font->FontSize + LayoutScale(4.0f)));
+// 		text.Format("Unlocked 21 Feb, 2019 @ 3:14am");
+// 		ImGui::RenderTextClipped(time_bb.Min, time_bb.Max, text.GetCharArray(), text.GetCharArray() + text.GetLength(),
+// 			nullptr, ImVec2(1.0f, 0.0f), &time_bb);
+// 		ImGui::PopFont();
+// 	}
+// #endif
+//
+// 	if (pressed)
+// 	{
+// 		// Anything?
+// 	}
+// }
+//
+// void FullscreenUI::DrawLeaderboardsWindow()
+// {
+// 	static constexpr float alpha = 0.8f;
+// 	static constexpr float heading_height_unscaled = 110.0f;
+//
+// 	// ensure image downloads still happen while we're paused
+// 	Achievements::ProcessPendingHTTPRequestsFromGSThread();
+//
+// 	ImGui::SetNextWindowBgAlpha(alpha);
+//
+// 	const bool is_leaderboard_open = s_open_leaderboard_id.has_value();
+// 	bool close_leaderboard_on_exit = false;
+//
+// 	const ImVec4 background(0.13f, 0.13f, 0.13f, alpha);
+// 	const ImVec2 display_size(ImGui::GetIO().DisplaySize);
+// 	const float padding = LayoutScale(10.0f);
+// 	const float spacing = LayoutScale(10.0f);
+// 	const float spacing_small = spacing / 2.0f;
+// 	float heading_height = LayoutScale(heading_height_unscaled);
+// 	if (is_leaderboard_open)
+// 	{
+// 		// Add space for a legend - spacing + 1 line of text + spacing + line
+// 		heading_height += spacing + LayoutScale(LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY) + spacing;
+// 	}
+//
+// 	const float rank_column_width =
+// 		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "99999").x;
+// 	const float name_column_width =
+// 		g_large_font->CalcTextSizeA(g_large_font->FontSize, std::numeric_limits<float>::max(), -1.0f, "WWWWWWWWWWWWWWWWWWWW").x;
+// 	const float column_spacing = spacing * 2.0f;
+//
+// 	if (BeginFullscreenWindow(ImVec2(0.0f, 0.0f), ImVec2(display_size.x, heading_height), "leaderboards_heading", background, 0.0f, 0.0f,
+// 			ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoScrollWithMouse))
+// 	{
+// 		ImRect bb;
+// 		bool visible, hovered;
+// 		/*bool pressed = */
+// 		MenuButtonFrame("leaderboards_heading", false, heading_height_unscaled, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+//
+// 		if (visible)
+// 		{
+// 			const float image_height = LayoutScale(85.0f);
+//
+// 			const ImVec2 icon_min(bb.Min + ImVec2(padding, padding));
+// 			const ImVec2 icon_max(icon_min + ImVec2(image_height, image_height));
+//
+// 			const std::string& icon_path = Achievements::GetGameIcon();
+// 			if (!icon_path.empty())
+// 			{
+// 				HostDisplayTexture* badge = GetCachedTexture(icon_path.c_str());
+// 				if (badge)
+// 				{
+// 					ImGui::GetWindowDrawList()->AddImage(
+// 						badge->GetHandle(), icon_min, icon_max, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f), IM_COL32(255, 255, 255, 255));
+// 				}
+// 			}
+//
+// 			float left = bb.Min.x + padding + image_height + spacing;
+// 			float right = bb.Max.x - padding;
+// 			float top = bb.Min.y + padding;
+// 			ImVec2 text_size;
+//
+// 			const u32 leaderboard_count = Achievements::GetLeaderboardCount();
+//
+// 			if (!is_leaderboard_open)
+// 			{
+// 				if (FloatingButton(ICON_FA_WINDOW_CLOSE, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) || WantsToCloseMenu())
+// 				{
+// 					ReturnToMainWindow();
+// 				}
+// 			}
+// 			else
+// 			{
+// 				if (FloatingButton(ICON_FA_CARET_SQUARE_LEFT, 10.0f, 10.0f, -1.0f, -1.0f, 1.0f, 0.0f, true, g_large_font) ||
+// 					WantsToCloseMenu())
+// 				{
+// 					close_leaderboard_on_exit = true;
+// 				}
+// 			}
+//
+// 			const ImRect title_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
+// 			const std::string& title = Achievements::GetGameTitle();
+//
+// 			top += g_large_font->FontSize + spacing;
+//
+// 			ImGui::PushFont(g_large_font);
+// 			ImGui::RenderTextClipped(title_bb.Min, title_bb.Max, title.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &title_bb);
+// 			ImGui::PopFont();
+//
+// 			std::string lb_description;
+// 			if (s_open_leaderboard_id.has_value())
+// 			{
+// 				const Achievements::Leaderboard* lboard = Achievements::GetLeaderboardByID(s_open_leaderboard_id.value());
+// 				if (lboard != nullptr)
+// 				{
+// 					const ImRect subtitle_bb(ImVec2(left, top), ImVec2(right, top + g_large_font->FontSize));
+// 					const std::string& subtitle = lboard->title;
+//
+// 					top += g_large_font->FontSize + spacing_small;
+//
+// 					ImGui::PushFont(g_large_font);
+// 					ImGui::RenderTextClipped(
+// 						subtitle_bb.Min, subtitle_bb.Max, subtitle.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &subtitle_bb);
+// 					ImGui::PopFont();
+//
+// 					lb_description = lboard->description;
+// 				}
+// 			}
+// 			else
+// 			{
+// 				lb_description = fmt::format("This game has {} leaderboards.", leaderboard_count);
+// 			}
+//
+// 			const ImRect summary_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+// 			top += g_medium_font->FontSize + spacing_small;
+//
+// 			ImGui::PushFont(g_medium_font);
+// 			ImGui::RenderTextClipped(
+// 				summary_bb.Min, summary_bb.Max, lb_description.c_str(), nullptr, nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+//
+// 			if (!Achievements::ChallengeModeActive())
+// 			{
+// 				const ImRect hardcore_warning_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+// 				top += g_medium_font->FontSize + spacing_small;
+//
+// 				ImGui::RenderTextClipped(hardcore_warning_bb.Min, hardcore_warning_bb.Max,
+// 					"Submitting scores is disabled because hardcore mode is off. Leaderboards are read-only.", nullptr, nullptr,
+// 					ImVec2(0.0f, 0.0f), &hardcore_warning_bb);
+// 			}
+//
+// 			ImGui::PopFont();
+// 		}
+//
+// 		if (is_leaderboard_open)
+// 		{
+// 			/*bool pressed = */
+// 			MenuButtonFrame("legend", false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY, &visible, &hovered, &bb.Min, &bb.Max, 0, alpha);
+//
+// 			if (visible)
+// 			{
+// 				const Achievements::Leaderboard* lboard = Achievements::GetLeaderboardByID(s_open_leaderboard_id.value());
+//
+// 				const float midpoint = bb.Min.y + g_large_font->FontSize + LayoutScale(4.0f);
+// 				float text_start_x = bb.Min.x + LayoutScale(15.0f) + padding;
+//
+// 				ImGui::PushFont(g_large_font);
+//
+// 				const ImRect rank_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 				ImGui::RenderTextClipped(rank_bb.Min, rank_bb.Max, "Rank", nullptr, nullptr, ImVec2(0.0f, 0.0f), &rank_bb);
+// 				text_start_x += rank_column_width + column_spacing;
+//
+// 				const ImRect user_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 				ImGui::RenderTextClipped(user_bb.Min, user_bb.Max, "Name", nullptr, nullptr, ImVec2(0.0f, 0.0f), &user_bb);
+// 				text_start_x += name_column_width + column_spacing;
+//
+// 				const ImRect score_bb(ImVec2(text_start_x, bb.Min.y), ImVec2(bb.Max.x, midpoint));
+// 				ImGui::RenderTextClipped(score_bb.Min, score_bb.Max,
+// 					lboard != nullptr && Achievements::IsLeaderboardTimeType(*lboard) ? "Time" : "Score", nullptr, nullptr,
+// 					ImVec2(0.0f, 0.0f), &score_bb);
+//
+// 				ImGui::PopFont();
+//
+// 				const float line_thickness = LayoutScale(1.0f);
+// 				const float line_padding = LayoutScale(5.0f);
+// 				const ImVec2 line_start(bb.Min.x, bb.Min.y + g_large_font->FontSize + line_padding);
+// 				const ImVec2 line_end(bb.Max.x, line_start.y);
+// 				ImGui::GetWindowDrawList()->AddLine(line_start, line_end, ImGui::GetColorU32(ImGuiCol_TextDisabled), line_thickness);
+// 			}
+// 		}
+// 	}
+// 	EndFullscreenWindow();
+//
+// 	ImGui::SetNextWindowBgAlpha(alpha);
+//
+// 	if (!is_leaderboard_open)
+// 	{
+// 		if (BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height), "leaderboards",
+// 				background, 0.0f, 0.0f, 0))
+// 		{
+// 			BeginMenuButtons();
+//
+// 			Achievements::EnumerateLeaderboards([](const Achievements::Leaderboard& lboard) -> bool {
+// 				DrawLeaderboardListEntry(lboard);
+//
+// 				return true;
+// 			});
+//
+// 			EndMenuButtons();
+// 		}
+// 		EndFullscreenWindow();
+// 	}
+// 	else
+// 	{
+// 		if (BeginFullscreenWindow(ImVec2(0.0f, heading_height), ImVec2(display_size.x, display_size.y - heading_height), "leaderboard",
+// 				background, 0.0f, 0.0f, 0))
+// 		{
+// 			BeginMenuButtons();
+//
+// 			const auto result = Achievements::TryEnumerateLeaderboardEntries(s_open_leaderboard_id.value(),
+// 				[rank_column_width, name_column_width, column_spacing](const Achievements::LeaderboardEntry& lbEntry) -> bool {
+// 					DrawLeaderboardEntry(lbEntry, rank_column_width, name_column_width, column_spacing);
+// 					return true;
+// 				});
+//
+// 			if (!result.has_value())
+// 			{
+// 				ImGui::PushFont(g_large_font);
+//
+// 				const ImVec2 pos_min(0.0f, heading_height);
+// 				const ImVec2 pos_max(display_size.x, display_size.y);
+// 				ImGui::RenderTextClipped(
+// 					pos_min, pos_max, "Downloading leaderboard data, please wait...", nullptr, nullptr, ImVec2(0.5f, 0.5f));
+//
+// 				ImGui::PopFont();
+// 			}
+//
+// 			EndMenuButtons();
+// 		}
+// 		EndFullscreenWindow();
+// 	}
+//
+// 	if (close_leaderboard_on_exit)
+// 		s_open_leaderboard_id.reset();
+// }
+//
+// void FullscreenUI::DrawAchievementsSettingsPage()
+// {
+// #ifdef ENABLE_RAINTEGRATION
+// 	if (Achievements::IsUsingRAIntegration())
+// 	{
+// 		BeginMenuButtons();
+// 		ActiveButton(ICON_FA_BAN "  RAIntegration is being used instead of the built-in achievements implementation.", false, false,
+// 			LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 		EndMenuButtons();
+// 		return;
+// 	}
+// #endif
+//
+// 	const auto lock = Achievements::GetLock();
+// 	if (Achievements::IsActive())
+// 		Achievements::ProcessPendingHTTPRequestsFromGSThread();
+//
+// 	SettingsInterface* bsi = GetEditingSettingsInterface();
+//
+// 	BeginMenuButtons();
+//
+// 	MenuHeading("Settings");
+// 	DrawToggleSetting(bsi, ICON_FA_TROPHY "  Enable Achievements",
+// 		"When enabled and logged in, XBSX2 will scan for achievements on startup.", "Achievements", "Enabled", false);
+//
+// 	const bool enabled = bsi->GetBoolValue("Achievements", "Enabled", false);
+// 	const bool challenge = bsi->GetBoolValue("Achievements", "ChallengeMode", false);
+//
+// 	DrawToggleSetting(bsi, ICON_FA_USER_FRIENDS "  Rich Presence",
+// 		"When enabled, rich presence information will be collected and sent to the server where supported.", "Achievements", "RichPresence",
+// 		true, enabled);
+// 	if (DrawToggleSetting(bsi, ICON_FA_HARD_HAT "  Hardcore Mode",
+// 			"\"Challenge\" mode for achievements. Disables save state, cheats, and slowdown functions, but you receive double the "
+// 			"achievement points.",
+// 			"Achievements", "ChallengeMode", false, enabled))
+// 	{
+// 		if (VMManager::HasValidVM() && bsi->GetBoolValue("Achievements", "ChallengeMode", false))
+// 			ShowToast(std::string(), "Hardcore mode will be enabled on next game restart.");
+// 	}
+// 	DrawToggleSetting(bsi, ICON_FA_LIST_OL "  Leaderboards", "Enables tracking and submission of leaderboards in supported games.",
+// 		"Achievements", "Leaderboards", true, enabled && challenge);
+// 	DrawToggleSetting(bsi, ICON_FA_MEDAL "  Test Unofficial Achievements",
+// 		"When enabled, XBSX2 will list achievements from unofficial sets. These achievements are not tracked by RetroAchievements.",
+// 		"Achievements", "UnofficialTestMode", false, enabled);
+// 	DrawToggleSetting(bsi, ICON_FA_STETHOSCOPE "  Test Mode",
+// 		"When enabled, XBSX2 will assume all achievements are locked and not send any unlock notifications to the server.", "Achievements",
+// 		"TestMode", false, enabled);
+//
+// 	MenuHeading("Account");
+// 	if (Achievements::IsLoggedIn())
+// 	{
+// 		ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
+// 		ActiveButton(fmt::format(ICON_FA_USER "  Username: {}", Achievements::GetUsername()).c_str(), false, false,
+// 			LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+//
+// 		const u64 ts = StringUtil::FromChars<u64>(bsi->GetStringValue("Achievements", "LoginTimestamp", "0")).value_or(0);
+// 		ActiveButton(fmt::format(ICON_FA_CLOCK "  Login token generated on {}", TimeToPrintableString(static_cast<time_t>(ts))).c_str(),
+// 			false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 		ImGui::PopStyleColor();
+//
+// 		if (MenuButton(ICON_FA_KEY "  Logout", "Logs out of RetroAchievements."))
+// 		{
+// 			Host::RunOnCPUThread([]() { Achievements::Logout(); });
+// 		}
+// 	}
+// 	else if (Achievements::IsActive())
+// 	{
+// 		ActiveButton(ICON_FA_USER "  Not Logged In", false, false, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+//
+// 		if (MenuButton(ICON_FA_KEY "  Login", "Logs in to RetroAchievements."))
+// 			ImGui::OpenPopup("Achievements Login");
+//
+// 		DrawAchievementsLoginWindow();
+// 	}
+// 	else
+// 	{
+// 		ActiveButton(ICON_FA_USER "  Achievements are disabled.", false, false, ImGuiFullscreen::LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 	}
+//
+// 	MenuHeading("Current Game");
+// 	if (Achievements::HasActiveGame())
+// 	{
+// 		ImGui::PushStyleColor(ImGuiCol_TextDisabled, ImGui::GetStyle().Colors[ImGuiCol_Text]);
+// 		ActiveButton(fmt::format(ICON_FA_BOOKMARK "  Game ID: {}", Achievements::GetGameID()).c_str(), false, false,
+// 			LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 		ActiveButton(fmt::format(ICON_FA_BOOK "  Game Title: {}", Achievements::GetGameTitle()).c_str(), false, false,
+// 			LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 		ActiveButton(fmt::format(ICON_FA_TROPHY "  Achievements: {} ({} points)", Achievements::GetAchievementCount(),
+// 						 Achievements::GetMaximumPointsForGame())
+// 						 .c_str(),
+// 			false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+//
+// 		const std::string& rich_presence_string = Achievements::GetRichPresenceString();
+// 		if (!rich_presence_string.empty())
+// 		{
+// 			ActiveButton(fmt::format(ICON_FA_MAP "  {}", rich_presence_string).c_str(), false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 		}
+// 		else
+// 		{
+// 			ActiveButton(ICON_FA_MAP "  Rich presence inactive or unsupported.", false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 		}
+//
+// 		ImGui::PopStyleColor();
+// 	}
+// 	else
+// 	{
+// 		ActiveButton(
+// 			ICON_FA_BAN "  Game not loaded or no RetroAchievements available.", false, false, LAYOUT_MENU_BUTTON_HEIGHT_NO_SUMMARY);
+// 	}
+//
+// 	EndMenuButtons();
+// }
+//
+// void FullscreenUI::DrawAchievementsLoginWindow()
+// {
+// 	ImGui::SetNextWindowSize(LayoutScale(700.0f, 0.0f));
+// 	ImGui::SetNextWindowPos(ImGui::GetIO().DisplaySize * 0.5f, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+//
+// 	ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, LayoutScale(10.0f));
+// 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, LayoutScale(20.0f, 20.0f));
+// 	ImGui::PushFont(g_large_font);
+//
+// 	bool is_open = true;
+// 	if (ImGui::BeginPopupModal("Achievements Login", &is_open, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize))
+// 	{
+//
+// 		ImGui::TextWrapped("Please enter your user name and password for retroachievements.org.");
+// 		ImGui::NewLine();
+// 		ImGui::TextWrapped("Your password will not be saved in XBSX2, an access token will be generated and used instead.");
+//
+// 		ImGui::NewLine();
+//
+// 		static char username[256] = {};
+// 		static char password[256] = {};
+//
+// 		ImGui::Text("User Name: ");
+// 		ImGui::SameLine(LayoutScale(200.0f));
+// 		ImGui::InputText("##username", username, sizeof(username));
+//
+// 		ImGui::Text("Password: ");
+// 		ImGui::SameLine(LayoutScale(200.0f));
+// 		ImGui::InputText("##password", password, sizeof(password), ImGuiInputTextFlags_Password);
+//
+// 		ImGui::NewLine();
+//
+// 		BeginMenuButtons();
+//
+// 		const bool login_enabled = (std::strlen(username) > 0 && std::strlen(password) > 0);
+//
+// 		if (ActiveButton(ICON_FA_KEY "  Login", false, login_enabled))
+// 		{
+// 			Achievements::LoginAsync(username, password);
+// 			std::memset(username, 0, sizeof(username));
+// 			std::memset(password, 0, sizeof(password));
+// 			ImGui::CloseCurrentPopup();
+// 		}
+//
+// 		if (ActiveButton(ICON_FA_TIMES "  Cancel", false))
+// 		{
+// 			std::memset(username, 0, sizeof(username));
+// 			std::memset(password, 0, sizeof(password));
+// 			ImGui::CloseCurrentPopup();
+// 		}
+//
+// 		EndMenuButtons();
+//
+// 		ImGui::EndPopup();
+// 	}
+//
+// 	ImGui::PopFont();
+// 	ImGui::PopStyleVar(2);
+// }
+//
+// #endif

--- a/xbsx2/Frontend/GameList.cpp
+++ b/xbsx2/Frontend/GameList.cpp
@@ -81,13 +81,13 @@ bool GameList::IsGameListLoaded()
 
 const char* GameList::EntryTypeToString(EntryType type)
 {
-	static std::array<const char*, static_cast<int>(EntryType::Count)> names = {{"PS2Disc", "PS1Disc", "ELF", "Playlist"}};
+	static std::array<const char*, static_cast<int>(EntryType::Count)> names = {{"PS2Disc", "PS1Disc", "ELF"}};
 	return names[static_cast<int>(type)];
 }
 
 const char* GameList::EntryTypeToDisplayString(EntryType type)
 {
-	static std::array<const char*, static_cast<int>(EntryType::Count)> names = {{"PS2 Disc", "PS1 Disc", "ELF", "Playlist"}};
+	static std::array<const char*, static_cast<int>(EntryType::Count)> names = {{"PS2 Disc", "PS1 Disc", "ELF"}};
 	return names[static_cast<int>(type)];
 }
 const char* GameList::RegionToString(Region region)

--- a/xbsx2/Frontend/GameList.h
+++ b/xbsx2/Frontend/GameList.h
@@ -36,7 +36,6 @@ namespace GameList
 		PS2Disc,
 		PS1Disc,
 		ELF,
-		Playlist,
 		Count
 	};
 

--- a/xbsx2/GS/GS.cpp
+++ b/xbsx2/GS/GS.cpp
@@ -1519,6 +1519,7 @@ void GSApp::Init()
 	m_default_configuration["linux_replay"]                               = "1";
 #endif
 	m_default_configuration["aa1"]                                        = "1";
+	m_default_configuration["accurate_date"]							  = "1";
 	m_default_configuration["accurate_blending_unit"]                     = "1";
 	m_default_configuration["AspectRatio"]                                = "1";
 	m_default_configuration["autoflush_sw"]                               = "1";

--- a/xbsx2/GS/GSVector.h
+++ b/xbsx2/GS/GSVector.h
@@ -15,6 +15,7 @@
 
 #include "PrecompiledHeader.h"
 #include "GSIntrin.h"
+#include <cstring>
 
 #pragma once
 
@@ -65,12 +66,12 @@ public:
 
 	constexpr bool operator==(const GSVector2T& v) const
 	{
-		return x == v.x && y == v.y;
+		return (std::memcmp(this, &v, sizeof(*this)) == 0);
 	}
 
 	constexpr bool operator!=(const GSVector2T& v) const
 	{
-		return x != v.x || y != v.y;
+		return (std::memcmp(this, &v, sizeof(*this)) != 0);
 	}
 
 	constexpr GSVector2T operator*(const GSVector2T& v) const

--- a/xbsx2/GS/Renderers/DX11/GSDevice11.cpp
+++ b/xbsx2/GS/Renderers/DX11/GSDevice11.cpp
@@ -682,7 +682,7 @@ void GSDevice11::StretchRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	// ps
 
 	PSSetShaderResources(sTex, nullptr);
-	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get(), nullptr);
+	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get());
 	PSSetShader(ps, ps_cb);
 
 	//
@@ -759,7 +759,7 @@ void GSDevice11::PresentRect(GSTexture* sTex, const GSVector4& sRect, GSTexture*
 	// ps
 
 	PSSetShaderResources(sTex, nullptr);
-	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get(), nullptr);
+	PSSetSamplerState(linear ? m_convert.ln.get() : m_convert.pt.get());
 	PSSetShader(m_present.ps[static_cast<u32>(shader)].get(), m_present.ps_cb.get());
 
 	//
@@ -955,7 +955,7 @@ void GSDevice11::SetupDATE(GSTexture* rt, GSTexture* ds, const GSVertexPT1* vert
 
 	// ps
 	PSSetShaderResources(rt, nullptr);
-	PSSetSamplerState(m_convert.pt.get(), nullptr);
+	PSSetSamplerState(m_convert.pt.get());
 	PSSetShader(m_convert.ps[static_cast<int>(datm ? ShaderConvert::DATM_1 : ShaderConvert::DATM_0)].get(), nullptr);
 
 	//
@@ -1181,10 +1181,9 @@ void GSDevice11::PSSetShaderResource(int i, GSTexture* sr)
 	m_state.ps_sr_views[i] = sr ? static_cast<ID3D11ShaderResourceView*>(*static_cast<GSTexture11*>(sr)) : nullptr;
 }
 
-void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1)
+void GSDevice11::PSSetSamplerState(ID3D11SamplerState* ss0)
 {
 	m_state.ps_ss[0] = ss0;
-	m_state.ps_ss[1] = ss1;
 }
 
 void GSDevice11::PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb)

--- a/xbsx2/GS/Renderers/DX11/GSDevice11.h
+++ b/xbsx2/GS/Renderers/DX11/GSDevice11.h
@@ -111,8 +111,8 @@ private:
 	// Increment this constant whenever shaders change, to invalidate user's shader cache.
 	static constexpr u32 SHADER_VERSION = 1;
 
-	static constexpr u32 MAX_TEXTURES = 4;
-	static constexpr u32 MAX_SAMPLERS = 2;
+	static constexpr u32 MAX_TEXTURES = 3;
+	static constexpr u32 MAX_SAMPLERS = 1;
 
 	int m_d3d_texsize;
 
@@ -220,7 +220,6 @@ private:
 	std::unordered_map<PSSelector, wil::com_ptr_nothrow<ID3D11PixelShader>, GSHWDrawConfig::PSSelectorHash> m_ps;
 	wil::com_ptr_nothrow<ID3D11Buffer> m_ps_cb;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11SamplerState>> m_ps_ss;
-	wil::com_ptr_nothrow<ID3D11SamplerState> m_palette_ss;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11DepthStencilState>> m_om_dss;
 	std::unordered_map<u32, wil::com_ptr_nothrow<ID3D11BlendState>> m_om_bs;
 	wil::com_ptr_nothrow<ID3D11RasterizerState> m_rs;
@@ -286,7 +285,7 @@ public:
 	void PSSetShaderResource(int i, GSTexture* sr);
 	void PSSetShader(ID3D11PixelShader* ps, ID3D11Buffer* ps_cb);
 	void PSUpdateShaderState();
-	void PSSetSamplerState(ID3D11SamplerState* ss0, ID3D11SamplerState* ss1);
+	void PSSetSamplerState(ID3D11SamplerState* ss0);
 
 	void OMSetDepthStencilState(ID3D11DepthStencilState* dss, u8 sref);
 	void OMSetBlendState(ID3D11BlendState* bs, float bf);

--- a/xbsx2/GS/Renderers/DX12/GSDevice12.h
+++ b/xbsx2/GS/Renderers/DX12/GSDevice12.h
@@ -111,7 +111,7 @@ public:
 		NUM_TFX_TEXTURES = 2,
 		NUM_TFX_RT_TEXTURES = 2,
 		NUM_TOTAL_TFX_TEXTURES = NUM_TFX_TEXTURES + NUM_TFX_RT_TEXTURES,
-		NUM_TFX_SAMPLERS = 2,
+		NUM_TFX_SAMPLERS = 1,
 		NUM_UTILITY_TEXTURES = 1,
 		NUM_UTILITY_SAMPLERS = 1,
 		CONVERT_PUSH_CONSTANTS_SIZE = 96,
@@ -272,7 +272,7 @@ public:
 	void IASetIndexBuffer(const void* index, size_t count);
 
 	void PSSetShaderResource(int i, GSTexture* sr, bool check_state);
-	void PSSetSampler(u32 index, GSHWDrawConfig::SamplerSelector sel);
+	void PSSetSampler(GSHWDrawConfig::SamplerSelector sel);
 
 	void OMSetRenderTargets(GSTexture* rt, GSTexture* ds, const GSVector4i& scissor);
 
@@ -397,8 +397,8 @@ private:
 
 	std::array<D3D12_GPU_VIRTUAL_ADDRESS, NUM_TFX_CONSTANT_BUFFERS> m_tfx_constant_buffers{};
 	std::array<D3D12::DescriptorHandle, NUM_TOTAL_TFX_TEXTURES> m_tfx_textures{};
-	std::array<D3D12::DescriptorHandle, NUM_TFX_SAMPLERS> m_tfx_samplers{};
-	std::array<u32, NUM_TFX_SAMPLERS> m_tfx_sampler_sel{};
+	D3D12::DescriptorHandle m_tfx_sampler;
+	u32 m_tfx_sampler_sel = 0;
 	D3D12::DescriptorHandle m_tfx_textures_handle_gpu;
 	D3D12::DescriptorHandle m_tfx_samplers_handle_gpu;
 	D3D12::DescriptorHandle m_tfx_rt_textures_handle_gpu;

--- a/xbsx2/GS/Renderers/HW/GSTextureCache.h
+++ b/xbsx2/GS/Renderers/HW/GSTextureCache.h
@@ -159,6 +159,7 @@ public:
 		std::unique_ptr<u32[]> m_valid;// each u32 bits map to the 32 blocks of that page
 		GSTexture* m_palette;
 		GSVector4i m_valid_rect;
+		GSVector2i m_lod;
 		u8 m_valid_hashes = 0;
 		u8 m_complete_layers = 0;
 		bool m_target;

--- a/xbsx2/SPU2/Host/Config.cpp
+++ b/xbsx2/SPU2/Host/Config.cpp
@@ -74,8 +74,8 @@ void ReadSettings()
 {
 	Interpolation = Host::GetIntSettingValue("SPU2/Mixing", "Interpolation", 5);
 	FinalVolume = ((float)Host::GetIntSettingValue("SPU2/Mixing", "FinalVolume", 100)) / 100;
-	if (FinalVolume > 1.0f)
-		FinalVolume = 1.0f;
+	if (FinalVolume > 2.0f)
+		FinalVolume = 2.0f;
 
 	AdvancedVolumeControl = Host::GetBoolSettingValue("SPU2/Mixing", "AdvancedVolumeControl", false);
 	VolumeAdjustCdb = Host::GetFloatSettingValue("SPU2/Mixing", "VolumeAdjustC", 0);

--- a/xbsx2/SaveState.cpp
+++ b/xbsx2/SaveState.cpp
@@ -215,6 +215,10 @@ SaveStateBase& SaveStateBase::FreezeBios()
 
 SaveStateBase& SaveStateBase::FreezeInternals()
 {
+#ifdef PCSX2_CORE
+	const u32 previousCRC = ElfCRC;
+#endif
+
 	// Print this until the MTVU problem in gifPathFreeze is taken care of (rama)
 	if (THREAD_VU1) Console.Warning("MTVU speedhack is enabled, saved states may not be stable");
 	
@@ -234,8 +238,22 @@ SaveStateBase& SaveStateBase::FreezeInternals()
 	char localDiscSerial[256];
 	StringUtil::Strlcpy(localDiscSerial, DiscSerial.c_str(), sizeof(localDiscSerial));
 	Freeze(localDiscSerial);
-	if (IsLoading())
+	{
 		DiscSerial = localDiscSerial;
+
+#ifdef PCSX2_CORE
+		if (ElfCRC != previousCRC)
+		{
+			// HACK: LastELF isn't in the save state... Load it before we go too far into restoring state.
+			// When we next bump save states, we should include it. We need this for achievements, because
+			// we want to load and activate achievements before restoring any of their tracked state.
+			if (const std::string& elf_override = VMManager::Internal::GetElfOverride(); !elf_override.empty())
+				cdvdReloadElfInfo(fmt::format("host:{}", elf_override));
+			else
+				cdvdReloadElfInfo();
+		}
+#endif
+	}
 
 	// Third Block - Cycle Timers and Events
 	// -------------------------------------

--- a/xbsx2/VMManager.cpp
+++ b/xbsx2/VMManager.cpp
@@ -1188,12 +1188,6 @@ bool VMManager::DoLoadState(const char* filename)
 		Host::OnSaveStateLoading(filename);
 		SaveState_UnzipFromDisk(filename);
 
-		// HACK: LastELF isn't in the save state...
-		if (!s_elf_override.empty())
-			cdvdReloadElfInfo(fmt::format("host:{}", s_elf_override));
-		else
-			cdvdReloadElfInfo();
-
 		UpdateRunningGame(false, false);
 		Host::OnSaveStateLoaded(filename, true);
 		return true;

--- a/xbsx2/Xbsx2Config.cpp
+++ b/xbsx2/Xbsx2Config.cpp
@@ -323,6 +323,7 @@ Xbsx2Config::GSOptions::GSOptions()
 	OsdShowIndicators = true;
 
 	HWDownloadMode = GSHardwareDownloadMode::Enabled;
+	AccurateDATE = false;
 	GPUPaletteConversion = false;
 	AutoFlushSW = true;
 	PreloadFrameWithGSData = false;
@@ -541,6 +542,7 @@ void Xbsx2Config::GSOptions::ReloadIniSettings()
 	GSSettingBool(OsdShowGSStats);
 	GSSettingBool(OsdShowIndicators);
 
+	GSSettingBoolEx(AccurateDATE, "accurate_date");
 	GSSettingBoolEx(GPUPaletteConversion, "paltex");
 	GSSettingBoolEx(AutoFlushSW, "autoflush_sw");
 	GSSettingBoolEx(PreloadFrameWithGSData, "preload_frame_with_gs_data");
@@ -692,7 +694,8 @@ VsyncMode Xbsx2Config::GetEffectiveVsyncMode() const
 
 Xbsx2Config::SPU2Options::SPU2Options()
 {
-	OutputModule = "cubeb";
+	bitset = 0;
+	OutputModule = "xaudio2";
 }
 
 void Xbsx2Config::SPU2Options::LoadSave(SettingsWrapper& wrap)
@@ -717,6 +720,7 @@ void Xbsx2Config::SPU2Options::LoadSave(SettingsWrapper& wrap)
 		SettingsWrapSection("SPU2/Output");
 
 		SettingsWrapEntry(OutputModule);
+		SettingsWrapEntry(BackendName);
 		SettingsWrapEntry(Latency);
 		SynchMode = static_cast<SynchronizationMode>(wrap.EntryBitfield(CURRENT_SETTINGS_SECTION, "SynchMode", static_cast<int>(SynchMode), static_cast<int>(SynchMode)));
 		SettingsWrapEntry(SpeakerConfiguration);


### PR DESCRIPTION
- Adds AccurateDATE back to XBSX2 but has it disabled by default.

- Fixes a bug where users needed to switch tabs to be able to move through the Game List when Game List was set as the default view.

- Fixes a bug with the cursor when selecting Close Game, before the cursor wouldn't automatically jump to an option but now it will automatically have "Exit without Saving" selected.

- Fixed a bug with the Audio Output module displaying as "Unknown".

- Audio latency is now 64ms by default.

- GameDB updates.

Backport - GS/TextureCache: Fix non-mipmap sources conflicting with mipmap sources https://github.com/PCSX2/pcsx2/commit/f1cb13fd944ca27109f35badef6d4ccfdc317ba1

Backport - GS: Use memcmp for GSVector2 comparisons https://github.com/PCSX2/pcsx2/commit/f2e6c61bfa514a8a65d4c837ec5fa87a3a6d36c4

Backport - GS/HW: Make trilinear filtering behavior consistent across backends https://github.com/PCSX2/pcsx2/commit/3bbb510b7a9ac4f3df500b3c9067c70b86c80814

Backport - GS/HW: Improve PS2 trilinear selection
https://github.com/PCSX2/pcsx2/commit/56d6014626a38a229cb58e51e90d1125f70b6562

Backport - GS/Vulkan: Actually store the readback buffer size https://github.com/PCSX2/pcsx2/commit/c2cafd1a800755f1025f37ce9b92c743ba83ef1e

Backport - VMManager: Reload save state ELF in internals https://github.com/PCSX2/pcsx2/commit/99fbe4e9ffd89624dc05f6862c3ad076ecf45d17

Backport - SPU2: Fix uninitialized bitset
https://github.com/PCSX2/pcsx2/commit/d1021749bcb56be14bf9c94adca8a9d67993b0b3

Backport - CDVD: Increase cycle accuracy + simulate speedup for CLV/CAS swap https://github.com/PCSX2/pcsx2/commit/86685a9db4fe5d31cab0b15b1d67caf209e7b478

Backport - GS/HW: Shuffle moves don't need barriers with fbfetch https://github.com/PCSX2/pcsx2/commit/2c1f0d248c33164185500c6a520d03580981974c

Backport - SPU: Allow up to 200% final volume
https://github.com/PCSX2/pcsx2/commit/2f7d45db09ba90fa6554b29ce5b39c9e72d15499

Backport - GameList: remove playlists
https://github.com/PCSX2/pcsx2/commit/4b652e6878bd4e863a83eb7b6845a099afdb8126

Backport - FullscreenUI: Remove m3u from open file filter https://github.com/PCSX2/pcsx2/commit/c0965f72053fc0b73ca8c78e8dee1d0d4d961f46